### PR TITLE
Add mobile responsiveness

### DIFF
--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -56,7 +56,7 @@ function LoginPage({ onLogin }: LoginPageProps) {
       <Paper
         component="form"
         onSubmit={handleSubmit}
-        sx={{ p: 4, maxWidth: 400, width: '100%' }}
+        sx={{ p: { xs: 2, sm: 4 }, mx: { xs: 2, sm: 0 }, maxWidth: 400, width: '100%' }}
         elevation={3}
       >
         <Typography variant="h5" mb={3} textAlign="center">

--- a/frontend/src/components/PhotoCard.tsx
+++ b/frontend/src/components/PhotoCard.tsx
@@ -20,9 +20,11 @@ const PhotoCard = memo(function PhotoCard({ photo, onClick }: PhotoCardProps) {
       sx={{
         cursor: 'pointer',
         transition: 'transform 0.15s ease-out, box-shadow 0.15s ease-out',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: 6,
+        '@media (hover: hover)': {
+          '&:hover': {
+            transform: 'translateY(-4px)',
+            boxShadow: 6,
+          },
         },
         position: 'relative',
         willChange: isHovered ? 'transform' : 'auto',

--- a/frontend/src/components/PhotoViewer.tsx
+++ b/frontend/src/components/PhotoViewer.tsx
@@ -18,6 +18,8 @@ import {
   Paper,
   Stack,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import type { Photo } from '@/types';
@@ -30,7 +32,9 @@ interface PhotoViewerProps {
 }
 
 function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
-  const [showMetadata, setShowMetadata] = useState(true);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [showMetadata, setShowMetadata] = useState(!isMobile);
   const currentIndex = photos.findIndex((p) => p.id === photo.id);
   const hasPrev = currentIndex > 0;
   const hasNext = currentIndex < photos.length - 1;
@@ -100,12 +104,15 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
       onClose={onClose}
       maxWidth={false}
       fullWidth
+      fullScreen={isMobile}
       PaperProps={{
-        sx: {
-          height: '95vh',
-          maxHeight: '95vh',
-          m: 2,
-        },
+        sx: isMobile
+          ? {}
+          : {
+              height: '95vh',
+              maxHeight: '95vh',
+              m: 2,
+            },
       }}
     >
       <Box sx={{ position: 'relative', height: '100%', display: 'flex' }}>
@@ -131,7 +138,14 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
             flexDirection: 'column',
           }}
         >
-          <Box sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              overflow: 'hidden',
+              flexDirection: isMobile ? 'column' : 'row',
+            }}
+          >
             <Box
               sx={{
                 flex: 1,
@@ -156,9 +170,9 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
             {showMetadata && (
               <Paper
                 sx={{
-                  width: 350,
+                  width: isMobile ? '100%' : 350,
                   overflowY: 'auto',
-                  p: 3,
+                  p: isMobile ? 2 : 3,
                   display: 'flex',
                   flexDirection: 'column',
                   gap: 2,
@@ -323,7 +337,7 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
             <IconButton
               onClick={() => onNavigate('prev')}
               disabled={!hasPrev}
-              size="small"
+              size={isMobile ? 'medium' : 'small'}
             >
               <ArrowBackIcon />
             </IconButton>
@@ -335,7 +349,7 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
             <IconButton
               onClick={() => onNavigate('next')}
               disabled={!hasNext}
-              size="small"
+              size={isMobile ? 'medium' : 'small'}
             >
               <ArrowForwardIcon />
             </IconButton>
@@ -344,7 +358,7 @@ function PhotoViewer({ photo, photos, onClose, onNavigate }: PhotoViewerProps) {
 
             <IconButton
               onClick={() => setShowMetadata(!showMetadata)}
-              size="small"
+              size={isMobile ? 'medium' : 'small'}
               color={showMetadata ? 'primary' : 'default'}
             >
               <InfoOutlinedIcon />

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -1,5 +1,6 @@
 import {
   Add as AddIcon,
+  FilterList as FilterListIcon,
   Folder as FolderIcon,
   Remove as RemoveIcon,
 } from '@mui/icons-material';
@@ -12,6 +13,8 @@ import {
   Select,
   Stack,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 import type { PhotoFilters } from '@/types';
@@ -22,6 +25,7 @@ interface ToolbarProps {
   onFilterChange: (filters: Partial<PhotoFilters>) => void;
   columnCount: number;
   onColumnCountChange: (count: number) => void;
+  onToggleFilters: () => void;
 }
 
 function Toolbar({
@@ -29,7 +33,10 @@ function Toolbar({
   onFilterChange,
   columnCount,
   onColumnCountChange,
+  onToggleFilters,
 }: ToolbarProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [folders, setFolders] = useState<string[]>([]);
 
   useEffect(() => {
@@ -94,9 +101,28 @@ function Toolbar({
         alignItems="center"
         justifyContent="space-between"
       >
+        {/* Filter toggle button (mobile) */}
+        {isMobile && (
+          <IconButton size="small" onClick={onToggleFilters}>
+            <FilterListIcon fontSize="small" />
+          </IconButton>
+        )}
+
         {/* Folder Browser */}
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          <FolderIcon fontSize="small" color="action" />
+        <Stack
+          direction="row"
+          spacing={0.5}
+          alignItems="center"
+          sx={{
+            flex: 1,
+            minWidth: 0,
+            overflowX: 'auto',
+            whiteSpace: 'nowrap',
+            '&::-webkit-scrollbar': { display: 'none' },
+            scrollbarWidth: 'none',
+          }}
+        >
+          <FolderIcon fontSize="small" color="action" sx={{ flexShrink: 0 }} />
           <Breadcrumbs
             separator="/"
             sx={{
@@ -181,29 +207,31 @@ function Toolbar({
           </Breadcrumbs>
         </Stack>
 
-        {/* Row Count Control */}
-        <Stack direction="row" spacing={0.5} alignItems="center">
-          <IconButton
-            size="small"
-            onClick={() => onColumnCountChange(Math.max(1, columnCount - 1))}
-            disabled={columnCount <= 1}
-          >
-            <RemoveIcon fontSize="small" />
-          </IconButton>
-          <Typography
-            variant="body2"
-            sx={{ minWidth: 48, textAlign: 'center' }}
-          >
-            {columnCount} {columnCount === 1 ? 'Column' : 'Columns'}
-          </Typography>
-          <IconButton
-            size="small"
-            onClick={() => onColumnCountChange(Math.min(8, columnCount + 1))}
-            disabled={columnCount >= 8}
-          >
-            <AddIcon fontSize="small" />
-          </IconButton>
-        </Stack>
+        {/* Row Count Control (hidden on mobile) */}
+        {!isMobile && (
+          <Stack direction="row" spacing={0.5} alignItems="center" sx={{ flexShrink: 0 }}>
+            <IconButton
+              size="small"
+              onClick={() => onColumnCountChange(Math.max(1, columnCount - 1))}
+              disabled={columnCount <= 1}
+            >
+              <RemoveIcon fontSize="small" />
+            </IconButton>
+            <Typography
+              variant="body2"
+              sx={{ minWidth: 48, textAlign: 'center' }}
+            >
+              {columnCount} {columnCount === 1 ? 'Column' : 'Columns'}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={() => onColumnCountChange(Math.min(8, columnCount + 1))}
+              disabled={columnCount >= 8}
+            >
+              <AddIcon fontSize="small" />
+            </IconButton>
+          </Stack>
+        )}
       </Stack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Auto-size grid columns based on viewport width (2 on mobile, 3/4/5 on larger screens); manual +/- override still works
- Filter drawer switches to temporary full-screen overlay on mobile with backdrop dismiss
- Toolbar gains a filter toggle icon on mobile, hides column count control, and breadcrumbs scroll horizontally
- PhotoViewer opens fullscreen on mobile with metadata stacked below the image (hidden by default)
- PhotoCard hover lift restricted to pointer devices via `@media (hover: hover)`
- LoginPage Paper gets responsive padding and margins
- Root layout constrained with `overflow: hidden` to prevent horizontal scrolling on mobile

## Files changed
- `frontend/src/App.tsx` — auto column sizing, responsive drawer variant, overflow fix
- `frontend/src/components/Toolbar.tsx` — filter toggle button, scrollable breadcrumbs, hide columns control
- `frontend/src/components/PhotoViewer.tsx` — fullscreen dialog, column layout, responsive metadata
- `frontend/src/components/PhotoCard.tsx` — hover media query
- `frontend/src/components/LoginPage.tsx` — responsive padding

## Test plan
- [ ] Chrome DevTools mobile emulator (iPhone SE / Pixel 5): 2 columns, no horizontal scroll
- [ ] Filter drawer opens as full-screen overlay on mobile, closes on backdrop tap
- [ ] Photo viewer is fullscreen with metadata below image on mobile
- [ ] Toolbar breadcrumbs scroll horizontally without overflow
- [ ] Column +/- control works on desktop, hidden on mobile
- [ ] Hover lift only triggers on devices with pointer (not touch)
- [ ] Login page has proper padding/margins on small screens
- [ ] `npm run build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)