### PR TITLE
Fix scroll breakage from mobile responsiveness PR

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -223,7 +223,7 @@ function App() {
 
   return (
     <AppThemeProvider>
-      <Box sx={{ display: 'flex', minHeight: '100vh', overflow: 'hidden', width: '100vw' }}>
+      <Box sx={{ display: 'flex', minHeight: '100vh', overflowX: 'hidden', width: '100vw' }}>
         {/* Left Sidebar for Filters */}
         <Drawer
           variant={isMobile ? 'temporary' : 'persistent'}
@@ -261,7 +261,6 @@ function App() {
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',
-            overflow: 'hidden',
           }}
         >
           {/* Toolbar */}
@@ -274,7 +273,7 @@ function App() {
           />
 
           {/* Photos Grid */}
-          <Box sx={{ flexGrow: 1, position: 'relative' }}>
+          <Box sx={{ flexGrow: 1, minHeight: 0, position: 'relative' }}>
             {/* Toggle button when sidebar is hidden (desktop only) */}
             {!showFilters && !isMobile && (
               <Box


### PR DESCRIPTION
## Summary
- Remove `overflow: hidden` from main content area — was clipping VirtualPhotoGrid's scroll container
- Change root container from `overflow: hidden` to `overflowX: hidden` — prevents horizontal scroll without blocking vertical
- Add `minHeight: 0` on Photos Grid wrapper — overrides flex default `min-height: auto` so the grid establishes its own scroll context

## Test plan
- [ ] Photo grid scrolls normally on both desktop and mobile
- [ ] No horizontal scroll on mobile
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)