### PR TITLE
Collapsible sort-field section headers in photo grid

### DIFF
--- a/designs/mobile-ux-improvements/SCOPES.yml
+++ b/designs/mobile-ux-improvements/SCOPES.yml
@@ -329,4 +329,4 @@ tasks:
       - Infinite scroll / load-more still functions properly
     depends_on: []
     effort: 5
-    status: scoped
+    status: testing

--- a/designs/mobile-ux-improvements/SCOPES.yml
+++ b/designs/mobile-ux-improvements/SCOPES.yml
@@ -329,4 +329,4 @@ tasks:
       - Infinite scroll / load-more still functions properly
     depends_on: []
     effort: 5
-    status: testing
+    status: implementing

--- a/designs/mobile-ux-improvements/SCOPES.yml
+++ b/designs/mobile-ux-improvements/SCOPES.yml
@@ -329,4 +329,4 @@ tasks:
       - Infinite scroll / load-more still functions properly
     depends_on: []
     effort: 5
-    status: implementing
+    status: completed

--- a/frontend/src/components/GalleryPage.tsx
+++ b/frontend/src/components/GalleryPage.tsx
@@ -337,6 +337,7 @@ function GalleryPage({ onLogout }: GalleryPageProps) {
               loadMore={handleLoadMore}
               loading={loading}
               columnCount={columnCount}
+              sortBy={filters.sortBy}
             />
           )}
         </Box>

--- a/frontend/src/components/VirtualPhotoGrid.tsx
+++ b/frontend/src/components/VirtualPhotoGrid.tsx
@@ -1,7 +1,9 @@
-import { Box, Button, CircularProgress } from '@mui/material';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { Box, Button, CircularProgress, Typography } from '@mui/material';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PhotoCard from '@/components/PhotoCard';
 import type { Photo } from '@/types';
+import { groupPhotosBySort } from '@/utils/groupPhotos';
 
 interface VirtualPhotoGridProps {
   photos: Photo[];
@@ -10,11 +12,29 @@ interface VirtualPhotoGridProps {
   loadMore: () => void;
   loading: boolean;
   columnCount: number;
+  sortBy?: string;
 }
 
-const GAP = 16; // MUI gap: 2 = theme.spacing(2) = 16px
-const PADDING = 16; // MUI p: 2 = 16px
+const GAP = 16;
+const PADDING = 16;
 const OVERSCAN = 2;
+const SECTION_HEADER_HEIGHT = 44;
+
+type VirtualRow =
+  | {
+      type: 'header';
+      y: number;
+      height: number;
+      sectionKey: string;
+      label: string;
+      photoCount: number;
+    }
+  | {
+      type: 'photos';
+      y: number;
+      height: number;
+      photos: Photo[];
+    };
 
 const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
   photos,
@@ -23,11 +43,24 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
   loadMore,
   loading,
   columnCount,
+  sortBy,
 }: VirtualPhotoGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const observerTarget = useRef<HTMLDivElement>(null);
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 20 });
   const [containerWidth, setContainerWidth] = useState(0);
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
+    new Set(),
+  );
+
+  // Clear collapsed sections when sort field changes
+  const prevSortByRef = useRef(sortBy);
+  useEffect(() => {
+    if (sortBy !== prevSortByRef.current) {
+      prevSortByRef.current = sortBy;
+      setCollapsedSections(new Set());
+    }
+  }, [sortBy]);
 
   // Measure container width so row height matches actual layout
   useEffect(() => {
@@ -45,33 +78,102 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
     containerWidth > 0
       ? (containerWidth - PADDING * 2 - (columnCount - 1) * GAP) / columnCount
       : 300;
-  const rowPitch = cellSize + GAP;
+
+  const toggleSection = useCallback((key: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Build layout with section headers and photo rows
+  const layout = useMemo(() => {
+    if (!sortBy) {
+      const rows: VirtualRow[] = [];
+      const totalPhotoRows = Math.ceil(photos.length / columnCount);
+      let y = PADDING;
+      for (let r = 0; r < totalPhotoRows; r++) {
+        const rowPhotos = photos.slice(
+          r * columnCount,
+          (r + 1) * columnCount,
+        );
+        rows.push({ type: 'photos', y, height: cellSize, photos: rowPhotos });
+        y += cellSize + GAP;
+      }
+      const totalHeight = rows.length > 0 ? y - GAP + PADDING : 0;
+      return { rows, totalHeight };
+    }
+
+    const sections = groupPhotosBySort(photos, sortBy);
+    const rows: VirtualRow[] = [];
+    let y = PADDING;
+
+    for (const section of sections) {
+      rows.push({
+        type: 'header',
+        y,
+        height: SECTION_HEADER_HEIGHT,
+        sectionKey: section.key,
+        label: section.label,
+        photoCount: section.photos.length,
+      });
+      y += SECTION_HEADER_HEIGHT + GAP;
+
+      if (!collapsedSections.has(section.key)) {
+        const photoRowCount = Math.ceil(section.photos.length / columnCount);
+        for (let r = 0; r < photoRowCount; r++) {
+          const rowPhotos = section.photos.slice(
+            r * columnCount,
+            (r + 1) * columnCount,
+          );
+          rows.push({
+            type: 'photos',
+            y,
+            height: cellSize,
+            photos: rowPhotos,
+          });
+          y += cellSize + GAP;
+        }
+      }
+    }
+
+    const totalHeight = rows.length > 0 ? y - GAP + PADDING : 0;
+    return { rows, totalHeight };
+  }, [photos, sortBy, columnCount, cellSize, collapsedSections]);
 
   // Calculate visible range based on scroll position
   const updateVisibleRange = useCallback(() => {
     const container = containerRef.current;
-    if (!container) return;
+    if (!container || layout.rows.length === 0) return;
 
     const scrollTop = container.scrollTop;
     const viewportHeight = container.clientHeight;
+    const overscanPx = OVERSCAN * (cellSize + GAP);
 
-    const startRow = Math.max(
-      0,
-      Math.floor(scrollTop / rowPitch) - OVERSCAN,
-    );
-    const endRow =
-      Math.ceil((scrollTop + viewportHeight) / rowPitch) + OVERSCAN;
+    let start = 0;
+    let end = layout.rows.length;
 
-    const startIndex = startRow * columnCount;
-    const endIndex = Math.min(photos.length, endRow * columnCount);
+    for (let i = 0; i < layout.rows.length; i++) {
+      if (layout.rows[i].y + layout.rows[i].height > scrollTop - overscanPx) {
+        start = i;
+        break;
+      }
+    }
+
+    for (let i = start; i < layout.rows.length; i++) {
+      if (layout.rows[i].y > scrollTop + viewportHeight + overscanPx) {
+        end = i;
+        break;
+      }
+    }
 
     setVisibleRange((prev) => {
-      if (prev.start === startIndex && prev.end === endIndex) {
-        return prev; // Same values, don't trigger re-render
-      }
-      return { start: startIndex, end: endIndex };
+      if (prev.start === start && prev.end === end) return prev;
+      return { start, end };
     });
-  }, [columnCount, photos.length, rowPitch]);
+  }, [layout.rows, cellSize]);
 
   // Update visible range on scroll
   useEffect(() => {
@@ -111,13 +213,7 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
     };
   }, [hasMore, loading, loadMore]);
 
-  const totalRows = Math.ceil(photos.length / columnCount);
-  const totalHeight =
-    totalRows > 0
-      ? PADDING * 2 + totalRows * cellSize + (totalRows - 1) * GAP
-      : 0;
-  const visiblePhotos = photos.slice(visibleRange.start, visibleRange.end);
-  const offsetY = Math.floor(visibleRange.start / columnCount) * rowPitch;
+  const visibleRows = layout.rows.slice(visibleRange.start, visibleRange.end);
 
   return (
     <Box
@@ -128,25 +224,84 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
         overflowX: 'hidden',
       }}
     >
-      <Box sx={{ height: totalHeight, position: 'relative' }}>
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
-            gap: 2,
-            p: 2,
-            transform: `translateY(${offsetY}px)`,
-            willChange: 'transform',
-          }}
-        >
-          {visiblePhotos.map((photo) => (
-            <PhotoCard
-              key={photo.id}
-              photo={photo}
-              onClick={() => onPhotoClick(photo)}
-            />
-          ))}
-        </Box>
+      <Box sx={{ height: layout.totalHeight, position: 'relative' }}>
+        {visibleRows.map((row) => {
+          if (row.type === 'header') {
+            const isCollapsed = collapsedSections.has(row.sectionKey);
+            return (
+              <Box
+                key={`header-${row.sectionKey}`}
+                onClick={() => toggleSection(row.sectionKey)}
+                sx={{
+                  position: 'absolute',
+                  top: row.y,
+                  left: PADDING,
+                  right: PADDING,
+                  height: SECTION_HEADER_HEIGHT,
+                  display: 'flex',
+                  alignItems: 'center',
+                  cursor: 'pointer',
+                  bgcolor: 'grey.100',
+                  borderRadius: 1,
+                  px: 1.5,
+                  userSelect: 'none',
+                  '&:hover': {
+                    bgcolor: 'grey.200',
+                  },
+                }}
+              >
+                <ExpandMoreIcon
+                  sx={{
+                    transform: isCollapsed
+                      ? 'rotate(-90deg)'
+                      : 'rotate(0deg)',
+                    transition: 'transform 0.2s',
+                    mr: 1,
+                    fontSize: 20,
+                    color: 'text.secondary',
+                  }}
+                />
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: 600, fontSize: '0.875rem' }}
+                >
+                  {row.label}
+                </Typography>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ ml: 1 }}
+                >
+                  ({row.photoCount})
+                </Typography>
+              </Box>
+            );
+          }
+
+          return (
+            <Box
+              key={`photos-${row.y}`}
+              sx={{
+                position: 'absolute',
+                top: row.y,
+                left: PADDING,
+                right: PADDING,
+                height: row.height,
+                display: 'grid',
+                gridTemplateColumns: `repeat(${columnCount}, 1fr)`,
+                gap: `${GAP}px`,
+              }}
+            >
+              {row.photos.map((photo) => (
+                <PhotoCard
+                  key={photo.id}
+                  photo={photo}
+                  onClick={() => onPhotoClick(photo)}
+                />
+              ))}
+            </Box>
+          );
+        })}
       </Box>
 
       <div ref={observerTarget} style={{ height: '20px' }} />

--- a/frontend/src/components/VirtualPhotoGrid.tsx
+++ b/frontend/src/components/VirtualPhotoGrid.tsx
@@ -2,6 +2,7 @@ import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
 import { Box, Button, CircularProgress, Typography } from '@mui/material';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PhotoCard from '@/components/PhotoCard';
+import { subtleBackground } from '@/styles/styleConsts';
 import type { Photo } from '@/types';
 import { groupPhotosBySort } from '@/utils/groupPhotos';
 
@@ -241,12 +242,11 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
                   display: 'flex',
                   alignItems: 'center',
                   cursor: 'pointer',
-                  bgcolor: 'grey.100',
-                  borderRadius: 1,
+                  bgcolor: subtleBackground('slightly'),
                   px: 1.5,
                   userSelect: 'none',
                   '&:hover': {
-                    bgcolor: 'grey.200',
+                    bgcolor: 'action.hover',
                   },
                 }}
               >
@@ -257,20 +257,16 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
                       : 'rotate(0deg)',
                     transition: 'transform 0.2s',
                     mr: 1,
-                    fontSize: 20,
-                    color: 'text.secondary',
+                    fontSize: 16,
                   }}
                 />
-                <Typography
-                  variant="subtitle2"
-                  sx={{ fontWeight: 600, fontSize: '0.875rem' }}
-                >
+                <Typography variant="caption" fontWeight="600">
                   {row.label}
                 </Typography>
                 <Typography
                   variant="caption"
                   color="text.secondary"
-                  sx={{ ml: 1 }}
+                  sx={{ ml: 0.75, fontSize: '0.65rem' }}
                 >
                   ({row.photoCount})
                 </Typography>

--- a/frontend/src/utils/groupPhotos.test.ts
+++ b/frontend/src/utils/groupPhotos.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { Photo } from '@/types';
+import { groupPhotosBySort } from './groupPhotos';
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: 1,
+    uuid: 'test',
+    filename: 'photo.jpg',
+    originalPath: '/img/photo.jpg',
+    thumbnailPath: '/thumb/photo.jpg',
+    blurhash: 'abc',
+    width: 4000,
+    height: 3000,
+    aspectRatio: 1.33,
+    camera: null,
+    lens: null,
+    dateCaptured: null,
+    iso: null,
+    shutterSpeed: null,
+    aperture: null,
+    focalLength: null,
+    keywords: null,
+    rating: null,
+    label: null,
+    fileSize: null,
+    mimeType: null,
+    createdAt: '2024-01-15T10:00:00Z',
+    updatedAt: '2024-01-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('groupPhotosBySort', () => {
+  it('groups photos by ISO value', () => {
+    const photos = [
+      makePhoto({ id: 1, iso: 100 }),
+      makePhoto({ id: 2, iso: 400 }),
+      makePhoto({ id: 3, iso: 100 }),
+    ];
+
+    const sections = groupPhotosBySort(photos, 'iso');
+    expect(sections).toHaveLength(2);
+    expect(sections[0].photos).toHaveLength(2);
+    expect(sections[0].label).toContain('100');
+    expect(sections[1].photos).toHaveLength(1);
+    expect(sections[1].label).toContain('400');
+  });
+
+  it('groups photos by camera name', () => {
+    const photos = [
+      makePhoto({ id: 1, camera: 'Canon EOS R6' }),
+      makePhoto({ id: 2, camera: 'NIKON Z 6_2' }),
+      makePhoto({ id: 3, camera: 'Canon EOS R6' }),
+    ];
+
+    const sections = groupPhotosBySort(photos, 'camera');
+    expect(sections).toHaveLength(2);
+    expect(sections[0].photos).toHaveLength(2);
+    expect(sections[1].photos).toHaveLength(1);
+  });
+
+  it('groups photos by date captured into day groups', () => {
+    const photos = [
+      makePhoto({ id: 1, dateCaptured: '2024-01-15T10:00:00Z' }),
+      makePhoto({ id: 2, dateCaptured: '2024-01-15T18:00:00Z' }),
+      makePhoto({ id: 3, dateCaptured: '2024-03-22T12:00:00Z' }),
+    ];
+
+    const sections = groupPhotosBySort(photos, 'dateCaptured');
+    expect(sections).toHaveLength(2);
+    expect(sections[0].photos).toHaveLength(2);
+    expect(sections[1].photos).toHaveLength(1);
+  });
+
+  it('puts photos with null sort field values into an "Unknown" group', () => {
+    const photos = [
+      makePhoto({ id: 1, iso: 200 }),
+      makePhoto({ id: 2, iso: null }),
+    ];
+
+    const sections = groupPhotosBySort(photos, 'iso');
+    expect(sections).toHaveLength(2);
+    const unknownSection = sections.find((s) => s.label.toLowerCase().includes('unknown'));
+    expect(unknownSection).toBeDefined();
+    expect(unknownSection!.photos).toHaveLength(1);
+  });
+
+  it('preserves photo order within each section', () => {
+    const photos = [
+      makePhoto({ id: 1, iso: 100 }),
+      makePhoto({ id: 2, iso: 100 }),
+      makePhoto({ id: 3, iso: 100 }),
+    ];
+
+    const sections = groupPhotosBySort(photos, 'iso');
+    expect(sections).toHaveLength(1);
+    expect(sections[0].photos.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+});

--- a/frontend/src/utils/groupPhotos.ts
+++ b/frontend/src/utils/groupPhotos.ts
@@ -1,0 +1,15 @@
+import type { Photo } from '@/types';
+
+export interface PhotoSection {
+  key: string;
+  label: string;
+  photos: Photo[];
+}
+
+/** Group a flat photo array into sections based on the current sort field. */
+export function groupPhotosBySort(
+  photos: Photo[],
+  sortBy: string,
+): PhotoSection[] {
+  return [];
+}

--- a/frontend/src/utils/groupPhotos.ts
+++ b/frontend/src/utils/groupPhotos.ts
@@ -6,10 +6,62 @@ export interface PhotoSection {
   photos: Photo[];
 }
 
+function getGroupKey(photo: Photo, sortBy: string): string {
+  switch (sortBy) {
+    case 'iso':
+      return photo.iso != null ? String(photo.iso) : '__unknown__';
+    case 'aperture':
+      return photo.aperture != null ? String(photo.aperture) : '__unknown__';
+    case 'dateCaptured':
+      return photo.dateCaptured ? photo.dateCaptured.substring(0, 10) : '__unknown__';
+    case 'createdAt':
+      return photo.createdAt ? photo.createdAt.substring(0, 10) : '__unknown__';
+    case 'camera':
+      return photo.camera ?? '__unknown__';
+    case 'filename':
+      return photo.filename ? photo.filename[0].toUpperCase() : '__unknown__';
+    default:
+      return '__unknown__';
+  }
+}
+
+function getGroupLabel(key: string, sortBy: string): string {
+  if (key === '__unknown__') return 'Unknown';
+  switch (sortBy) {
+    case 'iso':
+      return `ISO ${key}`;
+    case 'aperture':
+      return `f/${key}`;
+    case 'dateCaptured':
+    case 'createdAt':
+      return key;
+    case 'camera':
+      return key;
+    case 'filename':
+      return key;
+    default:
+      return key;
+  }
+}
+
 /** Group a flat photo array into sections based on the current sort field. */
 export function groupPhotosBySort(
   photos: Photo[],
   sortBy: string,
 ): PhotoSection[] {
-  return [];
+  const sections: PhotoSection[] = [];
+  const sectionMap = new Map<string, PhotoSection>();
+
+  for (const photo of photos) {
+    const key = getGroupKey(photo, sortBy);
+    let section = sectionMap.get(key);
+    if (!section) {
+      section = { key, label: getGroupLabel(key, sortBy), photos: [] };
+      sectionMap.set(key, section);
+      sections.push(section);
+    }
+    section.photos.push(photo);
+  }
+
+  return sections;
 }


### PR DESCRIPTION
## Summary
- Added `groupPhotosBySort` utility that groups a flat photo array into sections based on the active sort field (ISO, aperture, date, camera, filename)
- Overhauled `VirtualPhotoGrid` to render collapsible section headers between photo groups using absolute-positioned rows with pre-computed Y coordinates
- Each section header shows the sort field value (e.g., "ISO 400", "f/2.8", "2024-01-15") and photo count, with click-to-collapse/expand
- Virtual scrolling correctly handles mixed header/photo row heights

## Acceptance Criteria
- [x] Section headers appear between groups of photos when any sort is active
- [x] Headers display the sort field value (e.g., "ISO 400", "2024-01-15", "Canon EOS R5")
- [x] Clicking a section header collapses/expands that section's photos
- [x] Collapsed sections only show the header row, not the photos
- [x] Virtual scrolling still works correctly with mixed header/photo rows
- [x] Infinite scroll / load-more still functions properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)