### PR TITLE
Remove unused ChevronRightIcon import

### DIFF
--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -1,7 +1,6 @@
 import {
   Add as AddIcon,
   Check as CheckIcon,
-  ChevronRight as ChevronRightIcon,
   Close as CloseIcon,
   Folder as FolderIcon,
   FolderOpen as FolderOpenIcon,


### PR DESCRIPTION
## Summary
- Removes unused `ChevronRightIcon` import in Toolbar.tsx that was causing a TS build error (`TS6133`)

## Test plan
- [x] `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)