### PR TITLE
Fix photo viewer pagination and blurhash flicker on resize

### DIFF
--- a/frontend/src/components/GalleryPage.tsx
+++ b/frontend/src/components/GalleryPage.tsx
@@ -37,6 +37,8 @@ function GalleryPage({ onLogout }: GalleryPageProps) {
   const [columnCount, setColumnCount] = useState(4);
   const [columnOverride, setColumnOverride] = useState(false);
 
+  const pendingNavigateNextRef = useRef(false);
+
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -165,6 +167,17 @@ function GalleryPage({ onLogout }: GalleryPageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, fetchPhotos]);
 
+  // Auto-advance to next photo after pagination loads new photos
+  useEffect(() => {
+    if (pendingNavigateNextRef.current && selectedPhoto) {
+      const currentIndex = photos.findIndex((p) => p.id === selectedPhoto.id);
+      if (currentIndex !== -1 && currentIndex < photos.length - 1) {
+        pendingNavigateNextRef.current = false;
+        setSelectedPhoto(photos[currentIndex + 1]);
+      }
+    }
+  }, [photos, selectedPhoto]);
+
   const handleFilterChange = useCallback((newFilters: Partial<PhotoFilters>) => {
     setFilters((prev) => ({ ...prev, ...newFilters }));
   }, []);
@@ -183,11 +196,17 @@ function GalleryPage({ onLogout }: GalleryPageProps) {
     if (currentIndex === -1) return;
 
     if (direction === 'prev') {
-      const newIndex = (currentIndex - 1 + photos.length) % photos.length;
-      setSelectedPhoto(photos[newIndex]);
+      if (currentIndex === 0) return;
+      setSelectedPhoto(photos[currentIndex - 1]);
     } else {
-      const newIndex = (currentIndex + 1) % photos.length;
-      setSelectedPhoto(photos[newIndex]);
+      if (currentIndex === photos.length - 1) {
+        if (hasMore) {
+          pendingNavigateNextRef.current = true;
+          handleLoadMore();
+        }
+        return;
+      }
+      setSelectedPhoto(photos[currentIndex + 1]);
     }
   };
 

--- a/frontend/src/components/VirtualPhotoGrid.tsx
+++ b/frontend/src/components/VirtualPhotoGrid.tsx
@@ -330,7 +330,7 @@ const VirtualPhotoGrid = memo(function VirtualPhotoGrid({
 
           return (
             <Box
-              key={`photos-${row.y}`}
+              key={`photos-${row.photos[0].id}`}
               sx={{
                 position: 'absolute',
                 top: row.y,


### PR DESCRIPTION
## Summary
- Fix photo viewer arrow navigation to paginate instead of wrapping when reaching the end of loaded photos
- Use stable photo-id based React keys in the virtual grid to prevent all photos flickering to blurhash placeholders on window resize

## Test plan
- [ ] Open photo viewer, navigate with arrows to the end of loaded photos — should load the next page instead of wrapping
- [ ] Resize the browser window — photos should remain visible without briefly showing blurhash placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)