### PR TITLE
Rename app to "Your Own Gallery" and make web use its own origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Photo Gallery
+# Your Own Gallery
 
-Self-hosted photo gallery for browsing Lightroom photos quickly.
+Your whole Lightroom library, self-hosted and instant on your phone.
 
 ## Features
 
@@ -15,7 +15,7 @@ Self-hosted photo gallery for browsing Lightroom photos quickly.
 - Password protected
 - Easy Lightroom export workflow
 
-![Photo Gallery Grid](docs/images/grid.png)
+![Your Own Gallery Grid](docs/images/grid.png)
 ![Photo Detail Single Photo](docs/images/photo.png)
 ![Photo Stats](docs/images/stats.png)
 

--- a/cli/src/App.tsx
+++ b/cli/src/App.tsx
@@ -203,7 +203,7 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
   return (
     <Box flexDirection="column" gap={1}>
       <Text color="magenta" bold>
-        📷 Photo Gallery
+        📷 Your Own Gallery
       </Text>
 
       {screen === 'firstRun' && (

--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -37,7 +37,7 @@ resetCleanup();
 const args = process.argv.slice(2);
 
 if (args.includes('--help') || args.includes('-h')) {
-  console.log(`ingest-and-sync — photo-gallery orchestrator
+  console.log(`ingest-and-sync — Your Own Gallery orchestrator
 
 Usage:
   ./ingest-and-sync            Run the Source → Process → Sync wizard

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # frontend
 
-Expo (React Native) client for the photo-gallery app — runs on iOS, Android, and web.
+Expo (React Native) client for the Your Own Gallery app — runs on iOS, Android, and web.
 
 ## Develop
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,17 +1,18 @@
 {
   "expo": {
-    "name": "frontend",
-    "slug": "frontend",
+    "name": "Your Own Gallery",
+    "slug": "your-own-gallery",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "frontendv2",
+    "scheme": "yourowngallery",
     "userInterfaceStyle": "automatic",
     "ios": {
-      "bundleIdentifier": "com.travisbumgarner.photogallery",
+      "bundleIdentifier": "dev.travisbumgarner.yourowngallery",
       "supportsTablet": true
     },
     "android": {
+      "package": "dev.travisbumgarner.yourowngallery",
       "predictiveBackGestureEnabled": false
     },
     "web": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.2",
+    "@types/react-dom": "^19.2.3",
     "eslint": "^9.0.0",
     "eslint-config-expo": "~56.0.4",
     "typescript": "~6.0.3"

--- a/frontend/src/app/login.tsx
+++ b/frontend/src/app/login.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
+import { Platform } from 'react-native';
 import { Button, H4, Input, Paragraph, YStack } from 'tamagui';
 
 import { apiFetch } from '../lib/api';
@@ -16,6 +17,9 @@ export default function LoginScreen() {
   const router = useRouter();
   const palette = usePalette();
   const { setAuthenticated } = useAuth();
+  // Web is served by the backend (same origin), so there's no server to enter —
+  // the field and its handling are native-only.
+  const isWeb = Platform.OS === 'web';
   // Prefill with the saved server (returning user) or the dev default.
   const [server, setServer] = useState(getServerUrl());
   const [password, setPassword] = useState('');
@@ -24,15 +28,17 @@ export default function LoginScreen() {
 
   const handleSubmit = async () => {
     setError('');
-    const url = normalizeServerUrl(server);
-    if (!/^https?:\/\/.+/i.test(url)) {
-      setError('Enter a server address like https://photos.example.com');
-      return;
+    if (!isWeb) {
+      const url = normalizeServerUrl(server);
+      if (!/^https?:\/\/.+/i.test(url)) {
+        setError('Enter a server address like https://photos.example.com');
+        return;
+      }
+      // Persist + switch the active server before logging in, so apiFetch
+      // targets the address the user just entered.
+      await setServerUrl(url);
     }
     setLoading(true);
-    // Persist + switch the active server before logging in, so apiFetch targets
-    // the address the user just entered.
-    await setServerUrl(url);
     try {
       const response = await apiFetch('/api/auth/login', {
         method: 'POST',
@@ -46,7 +52,11 @@ export default function LoginScreen() {
         setError(data.error || 'Invalid password');
       }
     } catch {
-      setError(`Couldn't reach ${url}. Check the server address.`);
+      setError(
+        isWeb
+          ? "Couldn't reach the server."
+          : `Couldn't reach ${normalizeServerUrl(server)}. Check the server address.`,
+      );
     } finally {
       setLoading(false);
     }
@@ -76,16 +86,18 @@ export default function LoginScreen() {
           <Paragraph style={{ color: palette.error }}>{error}</Paragraph>
         ) : null}
 
-        <Input
-          placeholder="Server address (https://...)"
-          value={server}
-          onChangeText={setServer}
-          autoCapitalize="none"
-          autoCorrect={false}
-          keyboardType="url"
-          inputMode="url"
-          autoFocus={!server}
-        />
+        {isWeb ? null : (
+          <Input
+            placeholder="Server address (https://...)"
+            value={server}
+            onChangeText={setServer}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            inputMode="url"
+            autoFocus={!server}
+          />
+        )}
 
         <Input
           placeholder="Password"
@@ -93,12 +105,12 @@ export default function LoginScreen() {
           type="password"
           onChangeText={setPassword}
           secureTextEntry
-          autoFocus={!!server}
+          autoFocus={isWeb || !!server}
           onSubmitEditing={handleSubmit}
         />
 
         <Button
-          disabled={loading || !server || !password}
+          disabled={loading || !password || (!isWeb && !server)}
           onPress={handleSubmit}
         >
           {loading ? 'Signing in...' : 'Sign In'}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react';
 
 import { apiFetch } from './api';
-import { getServerUrl, loadServerUrl } from './serverUrl';
+import { isServerConfigured, loadServerUrl } from './serverUrl';
 
 type AuthState = {
   isAuthenticated: boolean;
@@ -24,12 +24,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     // Hydrate the saved server URL before checking auth — apiFetch reads it
-    // synchronously, so it must be in place first. With no server configured
-    // yet (fresh install) there's nothing to check; drop straight to the login
-    // screen, where the user enters the address + password.
+    // synchronously, so it must be in place first. On native with no server
+    // configured yet (fresh install) there's nothing to check; drop straight to
+    // the login screen, where the user enters the address + password. On web the
+    // backend is always the page origin, so we go straight to the auth check.
     loadServerUrl()
       .then(() => {
-        if (!getServerUrl()) {
+        if (!isServerConfigured()) {
           setIsAuthenticated(false);
           return;
         }

--- a/frontend/src/lib/serverUrl.ts
+++ b/frontend/src/lib/serverUrl.ts
@@ -1,14 +1,21 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
 
 const STORAGE_KEY = 'photoGallery.serverUrl.v1';
 
-// Build-time default. Useful for local dev (`expo start` with
+// On web the app is served BY the backend, so the backend is just this page's
+// origin: relative requests ('/api/...', '/images/...') hit it automatically and
+// getServerUrl() is always ''. Everything below — storage, hydration, the login
+// screen's "Server address" field — is native-only, where we ship one binary and
+// let each user point it at their own server.
+const IS_WEB = Platform.OS === 'web';
+
+// Build-time default (native only). Useful for local dev (`expo start` with
 // EXPO_PUBLIC_API_BASE_URL set) so you don't retype a URL on every reload.
 // Empty in a store build → the login screen's "Server address" field is the
-// only way in, which is the whole point: ship one binary, let each user point
-// it at their own server.
-const DEFAULT_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? '';
+// only way in, which is the whole point.
+const DEFAULT_URL = IS_WEB ? '' : (process.env.EXPO_PUBLIC_API_BASE_URL ?? '');
 
 // apiFetch/imageUrl/thumbnailUrl are synchronous, but AsyncStorage is async.
 // So we hydrate this module-level cache once at startup (loadServerUrl) before
@@ -34,9 +41,20 @@ export function isServerUrlHydrated(): boolean {
   return hydrated;
 }
 
+/** Whether a backend is configured. Always true on web (the page is served by
+ *  the backend); on native, true once the user has saved a server address. */
+export function isServerConfigured(): boolean {
+  return IS_WEB || current !== '';
+}
+
 /** Read the saved URL from storage into the sync cache. Call once at startup
  *  (before any apiFetch). Idempotent. */
 export async function loadServerUrl(): Promise<string> {
+  if (IS_WEB) {
+    // Same-origin: nothing to read, current stays '' (relative requests).
+    hydrated = true;
+    return current;
+  }
   try {
     const saved = await AsyncStorage.getItem(STORAGE_KEY);
     if (saved) current = saved;
@@ -48,8 +66,10 @@ export async function loadServerUrl(): Promise<string> {
   return current;
 }
 
-/** Persist and switch to a new backend URL, notifying subscribers. */
+/** Persist and switch to a new backend URL, notifying subscribers. Native-only;
+ *  on web the backend is fixed to the page origin. */
 export async function setServerUrl(url: string): Promise<void> {
+  if (IS_WEB) return;
   current = normalizeServerUrl(url);
   try {
     await AsyncStorage.setItem(STORAGE_KEY, current);

--- a/model-server
+++ b/model-server
@@ -204,7 +204,7 @@ fi
 touch .cli-cache
 
 GATEWAY_PORT="$(env_get GATEWAY_PORT)"; GATEWAY_PORT="${GATEWAY_PORT:-8443}"
-bold "=== Photo Gallery — model server ==="
+bold "=== Your Own Gallery — model server ==="
 dim "Serving the tagging LLM (Ollama) + vision-server (faces/dogs) to other"
 dim "machines on your LAN, behind one token-protected port. Nothing is ingested here."
 

--- a/offline-processing/src/label-app/public/index.html
+++ b/offline-processing/src/label-app/public/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Photo Gallery — Labeling</title>
+  <title>Your Own Gallery — Labeling</title>
   <style>
     :root {
       color-scheme: dark;

--- a/offline-processing/vision-server/server.py
+++ b/offline-processing/vision-server/server.py
@@ -1,5 +1,5 @@
 """
-Local vision sidecar for the photo gallery's people and dog search.
+Local vision sidecar for Your Own Gallery's people and dog search.
 
 Endpoints:
     POST /detect       - face detection + 512-d ArcFace embedding (InsightFace)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "photo-gallery",
+  "name": "your-own-gallery",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "photo-gallery",
+      "name": "your-own-gallery",
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
@@ -406,6 +406,7 @@
       },
       "devDependencies": {
         "@types/react": "~19.2.2",
+        "@types/react-dom": "^19.2.3",
         "eslint": "^9.0.0",
         "eslint-config-expo": "~56.0.4",
         "typescript": "~6.0.3"
@@ -2357,6 +2358,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "frontend/node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "frontend/node_modules/babel-preset-expo": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "photo-gallery",
+  "name": "your-own-gallery",
   "version": "1.0.0",
   "description": "Full-stack app with React Native (Expo), Express, and Drizzle ORM",
   "workspaces": [


### PR DESCRIPTION
## What

Two changes bundled:

**Web uses its own origin.** The frontend is served by the backend, so on web it already knows its origin — relative requests hit the right place. This drops the "Server address" field on web (now native-only), treats web as always-configured so it goes straight to the auth check instead of the fresh-install login gate, and fixes the submit button that would otherwise stay disabled forever on web. Added `@types/react-dom` so the web build typechecks.

**Rename "Photo Gallery" → "Your Own Gallery".**
- Expo: `name`, `slug`, `scheme`, iOS `bundleIdentifier` → `dev.travisbumgarner.yourowngallery`, plus a matching Android `package` (it had none).
- Root `package.json` / lockfile name.
- User-facing strings: CLI TUI header + `--help` banner, model-server banner, label-app `<title>`, vision-server docstring.
- READMEs.

## Intentionally left unchanged

Repo URL / dir, the prod host `photo-gallery.nfshost.com`, `photoGallery.*` AsyncStorage keys (renaming wipes saved settings/searches), tmp/backup file prefixes, the Docker image-tag example, and the `To Mobile Photo Gallery.lrtemplate` Lightroom preset filename.

## Verification

`frontend` and `cli` typecheck clean; all JSON parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)