### PR TITLE
fix(dev): let local web dev reach the backend (CORS + API base URL)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "NODE_ENV=development tsx watch src/index.ts",
     "build": "tsc -b",
     "start": "node dist/index.js",
     "db:generate": "drizzle-kit generate",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,13 +41,14 @@ app.use(
 );
 
 // Middleware
-const allowedOrigins = config.CORS_ORIGIN.split(',').map((o) => o.trim());
-app.use(
-  cors({
-    origin: allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins,
-    credentials: true,
-  }),
-);
+// CORS is only needed in local dev, where the Expo web dev server (Metro, on a
+// different origin/port) calls this backend. In production the backend serves the
+// web build from its own origin, so requests are same-origin and CORS is omitted.
+// Reflect the request origin (origin: true) rather than '*' so credentialed
+// (cookie) requests are allowed.
+if (config.NODE_ENV !== 'production') {
+  app.use(cors({ origin: true, credentials: true }));
+}
 app.use(express.json());
 app.use(
   compression({

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Local web dev only. `expo start --web` serves the app on Metro (:8081), which
+# has no API — point it at the separately-running backend (match backend/.env PORT).
+# Production web is served BY the backend (same origin) and ignores this
+# (serverUrl.ts: IS_WEB && !__DEV__ -> ''). Copy this to frontend/.env to use it.
+EXPO_PUBLIC_API_BASE_URL=http://localhost:8084

--- a/frontend/src/lib/serverUrl.ts
+++ b/frontend/src/lib/serverUrl.ts
@@ -11,11 +11,13 @@ const STORAGE_KEY = 'photoGallery.serverUrl.v1';
 // let each user point it at their own server.
 const IS_WEB = Platform.OS === 'web';
 
-// Build-time default (native only). Useful for local dev (`expo start` with
-// EXPO_PUBLIC_API_BASE_URL set) so you don't retype a URL on every reload.
-// Empty in a store build → the login screen's "Server address" field is the
-// only way in, which is the whole point.
-const DEFAULT_URL = IS_WEB ? '' : (process.env.EXPO_PUBLIC_API_BASE_URL ?? '');
+// Build-time default. Production web is served BY the backend (same origin) → ''.
+// In web dev (`expo start --web`, __DEV__ true) and on native, honor
+// EXPO_PUBLIC_API_BASE_URL so the app reaches a separately-running backend
+// without retyping a URL on every reload. Empty in a native store build → the
+// login screen's "Server address" field is the only way in, which is the point.
+const DEFAULT_URL =
+  IS_WEB && !__DEV__ ? '' : (process.env.EXPO_PUBLIC_API_BASE_URL ?? '');
 
 // apiFetch/imageUrl/thumbnailUrl are synchronous, but AsyncStorage is async.
 // So we hydrate this module-level cache once at startup (loadServerUrl) before


### PR DESCRIPTION
## Problem

`expo start --web` serves the app on Metro (`:8081`), a different origin from the backend (`:8084`). The web app makes **same-origin** `/api/*` requests (it assumes the backend serves the page, as in production), so in local web dev those hit Metro → **404**, and login failed.

## Fix

- **`frontend/src/lib/serverUrl.ts`** — web in dev (`__DEV__`) now honors `EXPO_PUBLIC_API_BASE_URL`; production web stays same-origin (`''`, served by the backend).
- **`backend/src/index.ts`** — CORS is now **dev-only** (`NODE_ENV !== 'production'`) and reflects the request origin with `credentials: true`. A cookie-based session can't use `Access-Control-Allow-Origin: *`, so we reflect the origin instead. Production is same-origin and needs no CORS.
- **`backend/package.json`** — the `dev` script sets `NODE_ENV=development` inline. The local `backend/.env` is prod-cloned (`NODE_ENV=production`), and dotenv won't override an already-set var, so the dev script is what flips dev mode on (enabling CORS, skipping static serving).
- **`frontend/.env.example`** — documents `EXPO_PUBLIC_API_BASE_URL` (the real `.env` is gitignored).

## Notes

- Session cookie works across `:8081`/`:8084` because cookies ignore port and `localhost` is one site (`SameSite=Lax` is fine).
- `CORS_ORIGIN` in `backend/.env` is now unused by code (left in the config schema; harmless).

## Test

1. `npm run dev:backend` (now runs as development → CORS on)
2. `cp frontend/.env.example frontend/.env`, then `expo start --web`
3. Log in with the `APP_PASSWORD` value from `backend/.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)