### PR TITLE
fix(auth): stop password managers clobbering the server field; longer session

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -71,6 +71,12 @@ app.use(
     secret: config.SESSION_SECRET,
     resave: false,
     saveUninitialized: false,
+    // Slide the expiry on every response so an active user is never logged out
+    // mid-use. Safe to keep long here: single user, self-hosted, and the server
+    // is read-only at runtime — a leaked cookie can only view, never mutate.
+    // (Sessions still reset on a backend restart: the default in-memory store is
+    // intentional — a persistent store would write at runtime.)
+    rolling: true,
     cookie: {
       httpOnly: true,
       sameSite: 'lax',
@@ -78,7 +84,7 @@ app.use(
       // https. NODE_ENV=production was wrong: it dropped the cookie when serving
       // the gallery over http://localhost, so login never stuck (401 after login).
       secure: 'auto',
-      maxAge: 30 * 60 * 1000, // 30 minutes
+      maxAge: 90 * 24 * 60 * 60 * 1000, // 90 days
     },
   }),
 );

--- a/frontend/src/app/login.tsx
+++ b/frontend/src/app/login.tsx
@@ -22,6 +22,14 @@ export default function LoginScreen() {
   const isWeb = Platform.OS === 'web';
   // Prefill with the saved server (returning user) or the dev default.
   const [server, setServer] = useState(getServerUrl());
+  // The server is device config, not a credential, and it's already persisted
+  // (serverUrl.ts). Hiding it once configured keeps the login form a single
+  // password field, so password managers don't autofill the (first) text field
+  // as a username and clobber the saved server. First run / "Change server"
+  // re-shows it.
+  const [showServerField, setShowServerField] = useState(
+    !isWeb && !getServerUrl(),
+  );
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -86,7 +94,7 @@ export default function LoginScreen() {
           <Paragraph style={{ color: palette.error }}>{error}</Paragraph>
         ) : null}
 
-        {isWeb ? null : (
+        {showServerField ? (
           <Input
             placeholder="Server address (https://...)"
             value={server}
@@ -95,9 +103,13 @@ export default function LoginScreen() {
             autoCorrect={false}
             keyboardType="url"
             inputMode="url"
+            // Tell password managers this is a URL, not a username, so they
+            // don't autofill it and overwrite the server address.
+            textContentType="URL"
+            autoComplete="off"
             autoFocus={!server}
           />
-        )}
+        ) : null}
 
         <Input
           placeholder="Password"
@@ -105,7 +117,10 @@ export default function LoginScreen() {
           type="password"
           onChangeText={setPassword}
           secureTextEntry
-          autoFocus={isWeb || !!server}
+          // Let password managers offer/save the password for this login.
+          textContentType="password"
+          autoComplete="password"
+          autoFocus={isWeb || !showServerField}
           onSubmitEditing={handleSubmit}
         />
 
@@ -115,6 +130,12 @@ export default function LoginScreen() {
         >
           {loading ? 'Signing in...' : 'Sign In'}
         </Button>
+
+        {!isWeb && !showServerField ? (
+          <Button size="$2" chromeless onPress={() => setShowServerField(true)}>
+            Change server
+          </Button>
+        ) : null}
       </YStack>
     </YStack>
   );


### PR DESCRIPTION
## Why
On mobile, the login screen put the **Server address** field first in the form, so password managers autofilled it as the "username" and overwrote the saved server when filling the password. The session cookie also expired after a flat 30 minutes (no rolling), logging you out mid-use.

## Changes
**`frontend/src/app/login.tsx`**
- Hide the server field once a server is saved (it's already persisted in `serverUrl.ts`), leaving a single password field that password managers handle cleanly.
- A **Change server** button (native) re-shows the field when you need to repoint it.
- Add `textContentType`/`autoComplete` hints so the server field is treated as a URL (not a username) and the password field offers fill/save.

**`backend/src/index.ts`**
- Session cookie `maxAge` 30 min → 90 days with `rolling: true`, so an active session never drops mid-use.
- Safe here: single user, self-hosted, server is read-only at runtime — a leaked cookie can only view, never mutate.

## Notes
- Enables **tap-to-fill** autofill; fully seamless iOS autofill (Associated Domains/AASA) is out of scope.
- Sessions still reset on a backend restart (default in-memory store, kept intentionally — a persistent store would write at runtime).

## Verification
- `npm run build -w backend` ✓
- `tsc --noEmit` (frontend) ✓
- `biome check` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)