### PR TITLE
Tune tagging speed with one parallelism knob

### DIFF
--- a/cli/src/App.tsx
+++ b/cli/src/App.tsx
@@ -352,41 +352,56 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
         />
       )}
 
-      {screen === 'process-confirm' && (
-        <Box flexDirection="column">
-          <Text bold>Process photos</Text>
-          <Text>
-            This ingests new photos, runs tagging + face/dog detection, then
-            publishes the gallery.
-          </Text>
-          <Text dimColor>
-            {countStagingPhotos()} new photo(s) in staging.
-          </Text>
-          <Text color="yellow">
-            ⚠ This can take a while — minutes to hours to days on a large library
-            or without a GPU.
-          </Text>
-          <Text color="yellow">
-            {'  '}Keep your laptop awake and plugged in until it finishes (it
-            won’t run while the machine is asleep). It’s resumable, so you can
-            stop and run it again later.
-          </Text>
-          <SelectInput
-            items={[
-              { label: 'Start processing', value: 'go' },
-              { label: '← Back', value: 'back' },
-            ]}
-            onSelect={(item) => {
-              if (item.value === 'go') {
-                setRunMode('process');
-                setScreen('run-pre');
-              } else {
-                setScreen('start');
-              }
-            }}
-          />
-        </Box>
-      )}
+      {screen === 'process-confirm' &&
+        (() => {
+          // Read fresh (not the mount-time cfg) so a just-changed server shows.
+          const current = loadExistingValues();
+          const host = current.MODEL_SERVER_HOST || '(not set)';
+          const model = current.MODEL_SERVER_MODEL || '(not set)';
+          return (
+            <Box flexDirection="column">
+              <Text bold>Process photos</Text>
+              <Text>
+                This ingests new photos, runs tagging + face/dog detection, then
+                publishes the gallery.
+              </Text>
+              <Text dimColor>
+                {countStagingPhotos()} new photo(s) in staging.
+              </Text>
+              <Text>
+                Tagging server: <Text color="cyan">{host}</Text> · model{' '}
+                <Text color="cyan">{model}</Text>
+              </Text>
+              <Text color="yellow">
+                ⚠ This can take a while — minutes to hours to days on a large
+                library or without a GPU.
+              </Text>
+              <Text color="yellow">
+                {'  '}Keep your laptop awake and plugged in until it finishes (it
+                won’t run while the machine is asleep). It’s resumable, so you
+                can stop and run it again later.
+              </Text>
+              <SelectInput
+                items={[
+                  { label: 'Start processing', value: 'go' },
+                  { label: 'Change tagging server', value: 'server' },
+                  { label: '← Back', value: 'back' },
+                ]}
+                onSelect={(item) => {
+                  if (item.value === 'go') {
+                    setRunMode('process');
+                    setScreen('run-pre');
+                  } else if (item.value === 'server') {
+                    setReturnTo('process-confirm');
+                    setScreen('setup');
+                  } else {
+                    setScreen('start');
+                  }
+                }}
+              />
+            </Box>
+          );
+        })()}
 
       {screen === 'create-confirm' && (
         <Box flexDirection="column">

--- a/cli/src/App.tsx
+++ b/cli/src/App.tsx
@@ -358,6 +358,9 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
           const current = loadExistingValues();
           const host = current.MODEL_SERVER_HOST || '(not set)';
           const model = current.MODEL_SERVER_MODEL || '(not set)';
+          // Only in the cache for a local Ollama; a remote server owns its own
+          // value (prompted by ./model-server on that box).
+          const par = current.OLLAMA_NUM_PARALLEL;
           return (
             <Box flexDirection="column">
               <Text bold>Process photos</Text>
@@ -371,6 +374,7 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
               <Text>
                 Tagging server: <Text color="cyan">{host}</Text> · model{' '}
                 <Text color="cyan">{model}</Text>
+                {par ? ` · ${par} in parallel` : ''}
               </Text>
               <Text color="yellow">
                 ⚠ This can take a while — minutes to hours to days on a large

--- a/cli/src/configFiles.ts
+++ b/cli/src/configFiles.ts
@@ -17,7 +17,9 @@ const IMAGE_RE = /\.(jpe?g|png|gif|bmp|tiff?|webp)$/i;
  * offline-processing/src/scan.ts VALID_IMAGE_EXTENSIONS). HEIC/RAW are skipped. */
 export const SUPPORTED_IMAGE_FORMATS = 'JPG, PNG, GIF, BMP, TIFF, WebP';
 // The "To Mobile Photo Gallery" preset renames every export to this suffix.
-const VIEWING_RE = /_exported_for_viewing_locally\.[^.]+$/i;
+// Exported so the Lightroom import step moves ONLY preset exports (not any
+// stray originals/sidecars that happen to share the folder).
+export const VIEWING_RE = /_exported_for_viewing_locally\.[^.]+$/i;
 
 // Single shared implementation (see shared/src/path.ts); re-exported so existing
 // `import { expandHome } from './configFiles.js'` call sites keep working. The
@@ -486,6 +488,21 @@ export const FIELDS: Field[] = [
     },
   },
   {
+    // Local Ollama only — a remote model server sets its own parallelism when
+    // ./model-server launches it on the other machine. Ollama serves this many
+    // tagging requests at once; higher is faster if the GPU/VRAM can take it,
+    // too high OOMs. Only applies when the CLI starts Ollama (an already-running
+    // Ollama keeps whatever it was launched with).
+    key: 'OLLAMA_NUM_PARALLEL',
+    label: 'Parallel tagging requests',
+    default: '1',
+    when: (v) =>
+      /localhost|127\.0\.0\.1|0\.0\.0\.0/.test(v.MODEL_SERVER_HOST ?? 'localhost'),
+    hint: 'How many images Ollama tags at once. Raise it if tagging is slow and the GPU has headroom; lower it if Ollama runs out of memory.',
+    validate: (val) =>
+      /^[1-9]\d*$/.test(val.trim()) ? null : 'Enter a whole number ≥ 1.',
+  },
+  {
     key: 'APP_PASSWORD',
     label: 'Gallery password',
     secret: true,
@@ -522,6 +539,9 @@ export function writeConfigFiles(v: Record<string, string>): {
     `MODEL_SERVER_HOST=${v.MODEL_SERVER_HOST}`,
     `MODEL_SERVER_MODEL=${v.MODEL_SERVER_MODEL ?? ''}`,
     v.MODEL_SERVER_API_KEY ? `MODEL_SERVER_API_KEY=${v.MODEL_SERVER_API_KEY}` : '',
+    // Local Ollama parallelism (preflight passes it when it starts Ollama);
+    // omitted for a remote host, which manages its own.
+    v.OLLAMA_NUM_PARALLEL ? `OLLAMA_NUM_PARALLEL=${v.OLLAMA_NUM_PARALLEL}` : '',
   ]
     .filter(Boolean)
     .join('\n')}\n`;

--- a/cli/src/importPhotos.ts
+++ b/cli/src/importPhotos.ts
@@ -7,13 +7,14 @@ import {
   unlinkSync,
 } from 'node:fs';
 import path from 'node:path';
-import { expandHome, STAGING_DIR } from './configFiles.js';
+import { expandHome, STAGING_DIR, VIEWING_RE } from './configFiles.js';
 
-// Move every image OUT of an import-from folder (argv[2]) and INTO the staging
-// inbox (STAGING_DIR), preserving nested structure. The wizard collects the
-// import folder, so this runs non-interactively. Lightroom = export with the
-// preset, then point the import folder here.
-const IMAGE_RE = /\.(jpe?g|png|gif|bmp|tiff?|webp)$/i;
+// Move Lightroom preset exports OUT of an import-from folder (argv[2]) and INTO
+// the staging inbox (STAGING_DIR), preserving nested structure. The wizard
+// collects the import folder, so this runs non-interactively. Lightroom = export
+// with the "To Mobile Photo Gallery" preset, then point the import folder here.
+// Only files carrying the preset's `_exported_for_viewing_locally.*` suffix are
+// moved, so unrelated originals/sidecars sharing the folder are left alone.
 const ARCHIVE_DIR_NAME = '_already_processed';
 
 function listDir(dir: string) {
@@ -31,7 +32,7 @@ function findImages(dir: string): string[] {
     if (e.isDirectory()) {
       if (e.name === ARCHIVE_DIR_NAME) continue; // never pull from the archive
       out.push(...findImages(full));
-    } else if (e.isFile() && IMAGE_RE.test(e.name)) {
+    } else if (e.isFile() && VIEWING_RE.test(e.name)) {
       out.push(full);
     }
   }
@@ -66,9 +67,13 @@ function main() {
   }
 
   const files = findImages(src);
-  console.log(`Found ${files.length} image(s) under ${src}`);
+  console.log(`Found ${files.length} preset export(s) under ${src}`);
   if (files.length === 0) {
-    console.log('Nothing to import.');
+    console.log(
+      'Nothing to import — no files with the "_exported_for_viewing_locally" ' +
+        'suffix here. Re-export with the "To Mobile Photo Gallery" preset, or ' +
+        'point at the folder you exported to.',
+    );
     return;
   }
   console.log(`Moving into staging ${dest} (folder structure preserved)…`);

--- a/cli/src/preflightModel.ts
+++ b/cli/src/preflightModel.ts
@@ -10,6 +10,11 @@ import { markOllama } from './cleanup.js';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const CLI_CACHE = path.join(ROOT, 'offline-processing', '.cli-cache');
 
+// Runner (Runner.tsx) turns a line with this prefix into the step's persistent
+// one-line summary (the "— …" suffix). Plain logs only show while the step runs.
+const SUMMARY_PREFIX = '@@PG_SUMMARY@@';
+const summary = (msg: string) => console.log(`${SUMMARY_PREFIX} ${msg}`);
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const isLocal = (host: string) => /localhost|127\.0\.0\.1|0\.0\.0\.0/.test(host);
 const ollamaInstalled = () =>
@@ -60,9 +65,19 @@ async function main() {
   );
   // Remote ./model-server gateway requires this bearer token; local Ollama ignores it.
   const key = cfg.MODEL_SERVER_API_KEY || undefined;
+  // How many tagging requests Ollama serves at once (local only). Applied when
+  // WE start Ollama below; a passthrough for an already-running one.
+  const numParallel = cfg.OLLAMA_NUM_PARALLEL;
 
   // 1. Ensure the server is reachable.
   let installed = await tags(host, key);
+  if (installed !== null && isLocal(host) && numParallel) {
+    // Env only takes effect at launch, and this Ollama is already up — so its
+    // parallelism is whatever it was started with, not necessarily this value.
+    console.log(
+      `Ollama is already running — OLLAMA_NUM_PARALLEL=${numParallel} only applies when it's (re)started. Quit Ollama and re-run to apply it.`,
+    );
+  }
   if (installed === null) {
     if (!isLocal(host)) {
       die(
@@ -77,12 +92,17 @@ async function main() {
         'then re-run. (It only needs installing once.)',
       );
     }
-    console.log('Starting Ollama…');
+    console.log(
+      `Starting Ollama…${numParallel ? ` (OLLAMA_NUM_PARALLEL=${numParallel})` : ''}`,
+    );
     // We started it (it wasn't already up) — record the pid so shutdown stops
     // our Ollama, and only ours.
     const ollama = spawn('ollama', ['serve'], {
       detached: true,
       stdio: 'ignore',
+      env: numParallel
+        ? { ...process.env, OLLAMA_NUM_PARALLEL: numParallel }
+        : process.env,
     });
     if (ollama.pid) markOllama(ollama.pid);
     ollama.unref();
@@ -129,7 +149,8 @@ async function main() {
   }
 
   // The tag task resolves the exact tag at call time — config stays as typed.
-  console.log(`Model "${resolved}" ready on ${host}.`);
+  // Emit as the step summary so the host/IP stays visible in the checklist.
+  summary(`${resolved} online at ${host}`);
 }
 
 main();

--- a/model-server
+++ b/model-server
@@ -97,9 +97,9 @@ ollama_loopback_only() { # listening on :11434 but only on loopback?
   [[ -n "$l" ]] && ! grep -qE '(\*|0\.0\.0\.0):11434' <<<"$l"
 }
 ollama_serve_bound() {
-  # OLLAMA_NUM_PARALLEL: how many tagging requests Ollama serves at once. Honour
-  # an already-set value (fallback to 1) — the client's setting doesn't reach
-  # this box, so it's tuned here in the environment that launches Ollama.
+  # OLLAMA_NUM_PARALLEL: how many tagging requests Ollama serves at once — only
+  # applies at launch, in Ollama's environment, so it's prompted + cached on THIS
+  # box (the client machine can't set it). The gateway reports it on /parallel.
   OLLAMA_HOST=0.0.0.0:11434 OLLAMA_NUM_PARALLEL="${OLLAMA_NUM_PARALLEL:-1}" \
     nohup ollama serve >/dev/null 2>&1 &
   disown 2>/dev/null || true
@@ -228,6 +228,25 @@ dmodel="$(env_get MODEL_SERVER_MODEL)"; dmodel="${dmodel:-qwen3-vl:8b}"
 dim "Vision model to serve — Ollama 'name:tag' (browse: https://ollama.com/search?c=vision)."
 export MODEL_SERVER_MODEL="$(ask "Vision model [$dmodel]: " "$dmodel")"
 env_set MODEL_SERVER_MODEL "$MODEL_SERVER_MODEL"
+
+# Parallel taggings: how many images Ollama tags at once (OLLAMA_NUM_PARALLEL).
+# It only applies when Ollama launches, on this box — so it's asked and cached
+# HERE, not on the client. The gateway exposes it on /parallel so the client
+# sizes its request window to match; a changed value restarts Ollama to apply.
+prev_par="$(env_get OLLAMA_NUM_PARALLEL)"; prev_par="${prev_par:-1}"
+dim "How many images to tag at once. Raise it while watching img/s on the main"
+dim "machine to find the sweet spot; lower it if Ollama runs out of memory."
+while :; do
+  OLLAMA_NUM_PARALLEL="$(ask "Parallel taggings [$prev_par]: " "$prev_par")"
+  [[ "$OLLAMA_NUM_PARALLEL" =~ ^[1-9][0-9]*$ ]] && break
+  err "Enter a whole number ≥ 1."
+done
+export OLLAMA_NUM_PARALLEL
+env_set OLLAMA_NUM_PARALLEL "$OLLAMA_NUM_PARALLEL"
+if [[ "$OLLAMA_NUM_PARALLEL" != "$prev_par" ]] && native_ollama_up; then
+  bold "Parallelism changed ($prev_par → $OLLAMA_NUM_PARALLEL) — restarting Ollama to apply it..."
+  ollama_restart_bound
+fi
 
 # Native, GPU-backed Ollama: ensure it's up and the model is pulled (up front).
 echo

--- a/model-server
+++ b/model-server
@@ -97,7 +97,11 @@ ollama_loopback_only() { # listening on :11434 but only on loopback?
   [[ -n "$l" ]] && ! grep -qE '(\*|0\.0\.0\.0):11434' <<<"$l"
 }
 ollama_serve_bound() {
-  OLLAMA_HOST=0.0.0.0:11434 nohup ollama serve >/dev/null 2>&1 &
+  # OLLAMA_NUM_PARALLEL: how many tagging requests Ollama serves at once. Honour
+  # an already-set value (fallback to 1) — the client's setting doesn't reach
+  # this box, so it's tuned here in the environment that launches Ollama.
+  OLLAMA_HOST=0.0.0.0:11434 OLLAMA_NUM_PARALLEL="${OLLAMA_NUM_PARALLEL:-1}" \
+    nohup ollama serve >/dev/null 2>&1 &
   disown 2>/dev/null || true
 }
 ollama_restart_bound() {
@@ -107,6 +111,7 @@ ollama_restart_bound() {
     ollama_serve_bound
   else
     launchctl setenv OLLAMA_HOST "0.0.0.0:11434" 2>/dev/null || true
+    launchctl setenv OLLAMA_NUM_PARALLEL "${OLLAMA_NUM_PARALLEL:-1}" 2>/dev/null || true
     osascript -e 'quit app "Ollama"' >/dev/null 2>&1 || true
     local t=0; while native_ollama_up; do [[ $t -ge 10 ]] && break; sleep 1; t=$((t + 1)); done
     open -a Ollama >/dev/null 2>&1 || true

--- a/offline-processing/Caddyfile
+++ b/offline-processing/Caddyfile
@@ -37,6 +37,13 @@
 		respond "Unauthorized" 401
 	}
 
+	# How many requests the native Ollama serves at once (the OLLAMA_NUM_PARALLEL
+	# it was launched with — ./model-server injects it via compose). The client
+	# reads this to size its tagging request window to match the server.
+	handle /parallel {
+		respond "{$OLLAMA_NUM_PARALLEL}" 200
+	}
+
 	# Ollama (tagging LLM) — native on the host, reached over host.docker.internal.
 	@ollama path /api/* /v1/*
 	handle @ollama {

--- a/offline-processing/docker-compose.yml
+++ b/offline-processing/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       # this service even for unrelated commands (e.g. a plain `up vision-server`),
       # which would then error out on a token they never needed.
       GATEWAY_TOKEN: "${GATEWAY_TOKEN:-}"
+      # The parallelism ./model-server launched the native Ollama with; served
+      # verbatim on /parallel so tagging clients can match their request window.
+      OLLAMA_NUM_PARALLEL: "${OLLAMA_NUM_PARALLEL:-1}"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
     # Reach the host's native Ollama (GPU) from inside the container. Automatic on

--- a/offline-processing/src/config.ts
+++ b/offline-processing/src/config.ts
@@ -27,6 +27,10 @@ const envSchema = z.object({
   MODEL_SERVER_HOST: z.string().optional(),
   MODEL_SERVER_MODEL: z.string().optional(),
   MODEL_SERVER_API_KEY: z.string().optional(),
+  // Local Ollama only: how many requests it serves at once (set at launch by
+  // the cli's preflight). A remote server's value lives on that box instead,
+  // reported by its gateway on /parallel.
+  OLLAMA_NUM_PARALLEL: z.string().optional(),
   VISION_SERVER_HOST: z.string().optional(),
   VISION_SERVER_API_KEY: z.string().optional(),
   // Optional override for the BGE embedder cache (defaults next to the images).

--- a/offline-processing/src/settings.ts
+++ b/offline-processing/src/settings.ts
@@ -57,7 +57,9 @@ const settingsSchema = z
       .default({}),
     tagging: z
       .object({
-        // Sliding-window concurrency of in-flight vision-LLM requests.
+        // CAP on in-flight vision-LLM requests. The actual window is derived
+        // from the server's parallelism (2× its OLLAMA_NUM_PARALLEL — see
+        // tag.ts); this only clamps it, so the default is effectively "no cap".
         concurrency: z.number().int().positive().default(2000),
         prompt: z.string().min(1).default(DEFAULT_TAG_PROMPT),
       })

--- a/offline-processing/src/tag.ts
+++ b/offline-processing/src/tag.ts
@@ -10,6 +10,35 @@ import { settings } from '@/settings.js';
 
 const RETRY_DELAYS_MS = [500, 1500, 3500];
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const isLocalHost = (host: string) =>
+  /localhost|127\.0\.0\.1|0\.0\.0\.0/.test(host);
+
+/** Connection-level failure (server unreachable / reset / gateway down), as
+ * opposed to a per-image error. For a REMOTE host this means "server went away"
+ * → pause and wait for it, rather than counting every remaining image failed. */
+function isConnLevel(err: unknown): boolean {
+  if (err instanceof TypeError) return true; // undici "fetch failed"
+  const status = (err as { status?: number })?.status;
+  return status === 502 || status === 503 || status === 504;
+}
+
+/** Is the model server answering right now? Used to poll for its return. */
+async function serverReachable(
+  host: string,
+  apiKey: string | undefined,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${host.replace(/\/+$/, '')}/api/tags`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      signal: AbortSignal.timeout(4000),
+    });
+    return res.ok || res.status === 401 || res.status === 403; // up (maybe auth)
+  } catch {
+    return false;
+  }
+}
+
 // A vision model spends most of its time encoding the image, and that cost grows
 // with resolution — full-size photos can take minutes per image on CPU (and blow
 // past the fetch timeout). ~1024px is plenty for tag-level understanding and cuts
@@ -223,16 +252,68 @@ async function main() {
     let processed = 0;
     let consecutiveFailures = 0;
     let nextIndex = 0;
+    let inFlight = 0;
+    const isRemote = !isLocalHost(modelHost);
+    // Rows that hit the server mid-outage go here to be retried once it's back,
+    // so a transient drop doesn't permanently "fail" them.
+    const retryQueue: (typeof untagged)[number][] = [];
+    // While set, the server is down and every worker awaits it before taking
+    // more work — the "pause". One worker runs the poll; the rest just wait.
+    let recovery: Promise<void> | null = null;
     const fmt = (ms: number) => `${(ms / 1000).toFixed(1)}s`;
+
+    // Remote server dropped out: pause all workers, poll until it answers, then
+    // resume. Only the first caller runs the loop; concurrent callers share it.
+    function pauseUntilServerBack(triggerErr: unknown): Promise<void> {
+      if (!recovery) {
+        recovery = (async () => {
+          console.error(
+            `\n⚠ Model server ${modelHost} stopped responding (${triggerErr}).`,
+          );
+          console.error(
+            '  Pausing — will resume automatically when it’s reachable again. Press q to stop.',
+          );
+          let waited = 0;
+          while (!(await serverReachable(modelHost, apiKey))) {
+            status(
+              `⚠ Model server unreachable — paused, waiting for it to come back (${waited}s)… press q to stop`,
+            );
+            await sleep(5000);
+            waited += 5;
+          }
+          console.log(`  Model server back after ~${waited}s — resuming.`);
+          status('resuming…');
+          consecutiveFailures = 0; // fresh streak after the outage
+        })().finally(() => {
+          recovery = null;
+        });
+      }
+      return recovery;
+    }
+
+    // Next unit of work: retries first, then the untagged list; null when both
+    // are drained. Kept in one place so the worker stays simple.
+    function nextRow(): (typeof untagged)[number] | null {
+      if (retryQueue.length) return retryQueue.shift() ?? null;
+      if (nextIndex < untagged.length) return untagged[nextIndex++];
+      return null;
+    }
 
     // Sliding-window concurrency: PARALLEL workers pull the next row as soon
     // as they're free, so a slow request doesn't stall faster ones in its batch.
     async function worker() {
       while (true) {
         if (aborted) return; // a systemic failure was detected — stop taking work
-        const i = nextIndex++;
-        if (i >= untagged.length) return;
-        const row = untagged[i];
+        if (recovery) await recovery; // server is down — hold until it's back
+        const row = nextRow();
+        if (!row) {
+          // No queued work, but an in-flight request could still requeue on an
+          // outage — only truly done once nothing is left and nothing's running.
+          if (inFlight === 0 && retryQueue.length === 0) return;
+          await sleep(100);
+          continue;
+        }
+        inFlight++;
         try {
           const t0 = Date.now();
           const filePath = path.join(localImagesDir, row.originalPath);
@@ -248,11 +329,8 @@ async function main() {
               .jpeg({ quality: 85 })
               .toBuffer()
           ).toString('base64');
-          const tRead = Date.now();
           const tags = await callGenerate(modelHost, model, apiKey, b64);
-          const tUpload = Date.now();
           const vec = await embedder.embed(tags);
-          const tEmbed = Date.now();
           await db
             .update(photos)
             .set({
@@ -264,28 +342,38 @@ async function main() {
           const tDone = Date.now();
           processed++;
           consecutiveFailures = 0; // a success clears the systemic-failure streak
-          const firstFiveTags = tags
-            .split(',')
-            .slice(0, 5)
-            .map((s) => s.trim())
-            .join(', ');
           const elapsed = (tDone - startTime) / 1000;
           const rate = processed / elapsed || 0;
+          // Per-image line: progress, filename, time, rate. No tags.
           console.log(
-            `  [${processed + failed}/${untagged.length}] ${row.filename}  read ${fmt(tRead - t0)}  upload ${fmt(tUpload - tRead)}  embed ${fmt(tEmbed - tUpload)}  db ${fmt(tDone - tEmbed)}  total ${fmt(tDone - t0)}  | ${rate.toFixed(2)} img/s | ${firstFiveTags}`,
+            `  [${processed + failed}/${untagged.length}] ${row.filename}  ${fmt(tDone - t0)}  ${rate.toFixed(2)} img/s`,
           );
           status(
             `${processed + failed} / ${untagged.length} photos · ${(elapsed / processed).toFixed(1)} s/img · ETA ${fmtDuration((untagged.length - (processed + failed)) * (elapsed / processed))}`,
           );
         } catch (err) {
-          failed++;
           consecutiveFailures++;
-          console.error(
-            `  [${processed + failed}/${untagged.length}] ${row.filename} FAILED: ${err}`,
-          );
-          if (consecutiveFailures >= ABORT_AFTER_CONSECUTIVE_FAILURES) {
-            aborted = err;
+          // Remote server dropped out → don't count these as failed; requeue
+          // the image and (once the streak confirms it's systemic) pause the
+          // whole run until the server returns, then resume.
+          if (isRemote && isConnLevel(err)) {
+            retryQueue.push(row);
+            if (consecutiveFailures >= ABORT_AFTER_CONSECUTIVE_FAILURES) {
+              await pauseUntilServerBack(err);
+            }
+          } else {
+            // Per-image error, or a local server that won't recover by waiting
+            // (e.g. OOM-killed) → count it and abort the run if it's systemic.
+            failed++;
+            console.error(
+              `  [${processed + failed}/${untagged.length}] ${row.filename} FAILED: ${err}`,
+            );
+            if (consecutiveFailures >= ABORT_AFTER_CONSECUTIVE_FAILURES) {
+              aborted = err;
+            }
           }
+        } finally {
+          inFlight--;
         }
       }
     }

--- a/offline-processing/src/tag.ts
+++ b/offline-processing/src/tag.ts
@@ -39,6 +39,32 @@ async function serverReachable(
   }
 }
 
+/** How many requests the model server tags at once — its launch-time
+ * OLLAMA_NUM_PARALLEL. Local: from .cli-cache (preflight launched Ollama with
+ * it). Remote: the ./model-server gateway reports the value it launched Ollama
+ * with on /parallel. null = unknown (older gateway / not configured). */
+async function serverParallelism(
+  host: string,
+  apiKey: string | undefined,
+  cfgValue: string | undefined,
+): Promise<number | null> {
+  if (isLocalHost(host)) {
+    const n = Number.parseInt(cfgValue ?? '', 10);
+    return n >= 1 ? n : null;
+  }
+  try {
+    const res = await fetch(`${host.replace(/\/+$/, '')}/parallel`, {
+      headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined,
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    const n = Number.parseInt((await res.text()).trim(), 10);
+    return n >= 1 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
 // A vision model spends most of its time encoding the image, and that cost grows
 // with resolution — full-size photos can take minutes per image on CPU (and blow
 // past the fetch timeout). ~1024px is plenty for tag-level understanding and cuts
@@ -198,6 +224,20 @@ async function main() {
   const modelHost = rawModelHost;
   const model = await resolveModel(modelHost, configuredModel);
 
+  // Size the request window from the server's parallelism: 2×N keeps every
+  // server slot fed while this side resizes/embeds/writes between requests,
+  // without flooding Ollama's request queue (overflow 503s would read as an
+  // outage). Unknown N (older ./model-server gateway) → a modest fixed window.
+  const serverN = await serverParallelism(
+    modelHost,
+    apiKey,
+    config.OLLAMA_NUM_PARALLEL,
+  );
+  const concurrency = Math.min(
+    settings.tagging.concurrency,
+    serverN ? serverN * 2 : 4,
+  );
+
   const localDbPath = config.DATABASE_URL;
   if (!localDbPath) {
     console.error('DATABASE_URL must be set (path to local sqlite).');
@@ -226,6 +266,9 @@ async function main() {
   console.log(`--- Tagging ---`);
   console.log(
     `  Model server: ${modelHost} (${model})${apiKey ? ' [auth]' : ''}`,
+  );
+  console.log(
+    `  Parallel:     ${concurrency} in flight (server tags ${serverN ?? '?'} at once)`,
   );
   console.log(`  Local DB:     ${localDbPath}`);
   console.log(`  Images dir:   ${localImagesDir}`);
@@ -379,9 +422,8 @@ async function main() {
     }
 
     await Promise.all(
-      Array.from(
-        { length: Math.min(settings.tagging.concurrency, untagged.length) },
-        () => worker(),
+      Array.from({ length: Math.min(concurrency, untagged.length) }, () =>
+        worker(),
       ),
     );
 


### PR DESCRIPTION
Tagging speed is now tunable with a single number — how many images Ollama tags at once — set and remembered wherever Ollama actually runs:

- **Remote GPU box:** `./model-server` prompts for it (remembers the last value) and restarts Ollama when it changes. The gateway reports the value on an authenticated `/parallel` route.
- **Local:** `./ingest-and-sync` setup asks for it and applies it when starting Ollama.

The client no longer floods the server with up to 2000 concurrent requests (which overflowed Ollama's queue and made 503s look like outages). It derives its in-flight window from the server's parallelism (2×N) and prints it in the tagging output, so tuning is: change the number, re-run, watch img/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)