### PR TITLE
Fix textual image search returning nothing in prod

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -18,6 +18,12 @@ const base = {
   SESSION_SECRET: z.string().min(1),
   APP_PASSWORD: z.string().min(1),
   CORS_ORIGIN: z.string().min(1),
+  // Where the text-embedding model (bge-small-en-v1.5) is cached on disk. Must
+  // be absolute for the same reason .env is loaded by path above: the daemon
+  // doesn't cd, so a relative path resolves against an arbitrary cwd — and a
+  // miss there means a silent 33MB HuggingFace download at first search, into
+  // a directory that may not even be writable.
+  MODEL_CACHE_DIR: z.string().min(1),
 };
 
 // Both supported targets (this computer, and a box you rsync to like

--- a/backend/src/contentSearch.ts
+++ b/backend/src/contentSearch.ts
@@ -6,7 +6,9 @@ import { photos } from 'shared/db/schema';
 import { config } from './config.js';
 
 const EMBED_DIM = 384;
-const MODEL_CACHE_DIR = path.resolve('models/bge-small-en-v1.5');
+// Resolved from config, not the cwd — the daemon starts the server without
+// cd'ing into the app dir.
+const MODEL_CACHE_DIR = path.resolve(config.MODEL_CACHE_DIR);
 
 interface MatrixEntry {
   uuid: string;
@@ -62,11 +64,20 @@ let embedderInflight: Promise<WasmEmbedder> | null = null;
 async function getEmbedder(): Promise<WasmEmbedder> {
   if (embedder) return embedder;
   if (embedderInflight) return embedderInflight;
-  embedderInflight = WasmEmbedder.create(MODEL_CACHE_DIR).then((e) => {
-    embedder = e;
-    embedderInflight = null;
-    return e;
-  });
+  // Clear the cached promise on failure too, so a transient model-load error
+  // (e.g. a blipped download) doesn't wedge search for the process lifetime by
+  // handing every later caller the same rejected promise.
+  embedderInflight = WasmEmbedder.create(MODEL_CACHE_DIR).then(
+    (e) => {
+      embedder = e;
+      embedderInflight = null;
+      return e;
+    },
+    (err) => {
+      embedderInflight = null;
+      throw err;
+    },
+  );
   return embedderInflight;
 }
 

--- a/cli/src/configFiles.ts
+++ b/cli/src/configFiles.ts
@@ -330,9 +330,14 @@ export const FIELDS: Field[] = [
     key: 'MODEL_SERVER_HOST',
     label: 'Where’s the tagging model running?',
     default: 'http://localhost:11434',
-    hint: 'This computer — I’ll start it for you. Another machine — run `./model-server` there first, then enter the address it prints (see offline-processing/README.md → “Run the models on another machine”).',
+    hint: 'Enter a URL. This computer: http://localhost:11434 (the default — I’ll start it for you). Another machine: run `./model-server` there first and paste the http:// address it prints (see offline-processing/README.md → “Run the models on another machine”).',
     validate: async (host) => {
       if (!host) return 'Required.';
+      // Catch a non-URL (e.g. someone typing a phrase from the hint) before the
+      // fetch below, which would otherwise fail as an unhelpful "can't reach".
+      if (!/^https?:\/\//i.test(host)) {
+        return `This needs a URL, not a name. For this computer use http://localhost:11434; for another machine paste the http:// address ./model-server printed there.`;
+      }
       if (/localhost|127\.0\.0\.1|0\.0\.0\.0/.test(host)) return null; // local: started for you
       const h = host.replace(/\/+$/, '');
       try {

--- a/cli/src/configFiles.ts
+++ b/cli/src/configFiles.ts
@@ -138,6 +138,10 @@ const DATA_DIR = path.join(ROOT, 'data');
 const DEST_DIR = path.join(DATA_DIR, 'out');
 const INGEST_DB = path.join(DATA_DIR, 'ingest.sqlite');
 const SERVED_DB = path.join(DATA_DIR, 'served.sqlite');
+// Text-embedding model cache. Must match offline-processing's modelCacheDir()
+// (<DESTINATION_DIRECTORY>/../models/…) so the prefetch step and the server
+// share one copy instead of each downloading their own.
+const MODEL_CACHE_DIR = path.join(DATA_DIR, 'models', 'bge-small-en-v1.5');
 
 // TEMPORARY (remove after the testing push): wipe ALL local state back to a
 // fresh-checkout state so an end-to-end run can be repeated from zero. Removes
@@ -265,6 +269,12 @@ export function migrateConfig(): boolean {
       // Docker vision-server is published on localhost:8090 for native tasks.
       if (p === CLI_CACHE && !/^VISION_SERVER_HOST=/m.test(txt)) {
         txt = `${txt.replace(/\n?$/, '\n')}${VISION_SERVER_HOST_LINE}\n`;
+      }
+      // Back-fill MODEL_CACHE_DIR for backend configs written before content
+      // search read it from env (it used to resolve against the cwd). The
+      // backend now requires it, so without this an existing .env fails boot.
+      if (p === BACKEND_ENV && !/^MODEL_CACHE_DIR=/m.test(txt)) {
+        txt = `${txt.replace(/\n?$/, '\n')}MODEL_CACHE_DIR=${MODEL_CACHE_DIR}\n`;
       }
       if (txt !== orig) {
         writeFileSync(p, txt);
@@ -555,6 +565,7 @@ export function writeConfigFiles(v: Record<string, string>): {
     `APP_PASSWORD=${v.APP_PASSWORD}`,
     'CORS_ORIGIN=*',
     `STORAGE_URL=file://${DEST_DIR}`,
+    `MODEL_CACHE_DIR=${MODEL_CACHE_DIR}`,
     // Discriminator for the backend's boot-time config validation (per host).
     `BACKEND_SERVER=${v.DEPLOY_TARGET || 'localhost'}`,
   ]

--- a/deploy/nearlyfreespeech/deploy.sh
+++ b/deploy/nearlyfreespeech/deploy.sh
@@ -105,6 +105,7 @@ NODE_ENV=production
 BACKEND_SERVER=nearlyfreespeech
 DATABASE_URL=$REMOTE_DIR/data/served.sqlite
 STORAGE_URL=file://$REMOTE_DIR/data/out
+MODEL_CACHE_DIR=$REMOTE_DIR/data/models/bge-small-en-v1.5
 APP_PASSWORD=$APP_PASSWORD
 SESSION_SECRET=$SESSION_SECRET
 CORS_ORIGIN=${SITE_URL:-*}
@@ -138,6 +139,21 @@ rsync -azPh -e "$RSH" --delete --timeout=300 backend/dist/ "$REMOTE:$REMOTE_DIR/
 rsync -azPh -e "$RSH" --delete --timeout=300 backend/frontend-dist/ "$REMOTE:$REMOTE_DIR/frontend-dist/"
 if [ -d backend/drizzle ]; then
   rsync -azPh -e "$RSH" --delete --timeout=300 backend/drizzle/ "$REMOTE:$REMOTE_DIR/drizzle/"
+fi
+
+# The text-embedding model (~33MB) that content search runs in-process to embed
+# each query. Ship it rather than letting the host fetch it from HuggingFace on
+# first search: that download is a silent 500 if the box has no outbound HTTPS,
+# and it re-downloads on every deploy. gitignored (**/models/), so it comes from
+# the local prefetch — publish is the only thing that populates it.
+if [ -d data/models/bge-small-en-v1.5 ]; then
+  echo "🧠 Syncing text-embedding model…"
+  ssh $KEYOPT "$REMOTE" "mkdir -p '$REMOTE_DIR/data/models'"
+  rsync -azPh -e "$RSH" --timeout=300 data/models/bge-small-en-v1.5/ \
+    "$REMOTE:$REMOTE_DIR/data/models/bge-small-en-v1.5/"
+else
+  echo "⚠️  data/models/bge-small-en-v1.5 missing — content search will try to"
+  echo "   download it on the host at first query. Run ./ingest-and-sync to prefetch."
 fi
 
 echo "📦 Installing production dependencies on the host…"

--- a/deploy/nearlyfreespeech/push.sh
+++ b/deploy/nearlyfreespeech/push.sh
@@ -63,6 +63,37 @@ fi
 echo "🗄️  Loading the read-only DB on the host…"
 ssh $KEYOPT "$REMOTE" "cd '$REMOTE_DIR' && node dist/boot.js"
 
+# Prune stale DB artifacts on the host. publish.ts prunes these locally, but the
+# default push is additive (no --delete), so that pruning never propagates and
+# the host grows without bound. Runs AFTER boot.js, so the slim snapshot the
+# server just loaded is already on disk as data/served.sqlite.
+#
+# Kept deliberately: db/ingest.sqlite (the fat DB). pull.sh restores a wiped
+# machine from it, so the host doubles as its offsite copy — never prune it.
+echo "🧹 Pruning stale DB artifacts on the host…"
+ssh $KEYOPT "$REMOTE" "
+  set -eu
+  cd '$REMOTE_DIR/data/out/db' 2>/dev/null || exit 0
+
+  # Old slim snapshots: only the version 'latest' points at is ever served, and
+  # any older one is regenerable from the fat DB sitting next to it.
+  if [ -f latest ]; then
+    keep=\"prod-\$(cat latest | tr -d '\\r\\n').sqlite\"
+    for f in prod-*.sqlite; do
+      [ -e \"\$f\" ] || continue
+      [ \"\$f\" = \"\$keep\" ] || { rm -f \"\$f\" && echo \"   removed \$f\"; }
+    done
+  fi
+
+  # Fat DB archives: keep the newest BACKUPS_TO_KEEP=5, matching publish.ts.
+  # Sort by name, not mtime — the version stamp is ISO-ish so it sorts
+  # chronologically, and rsync mtimes are less trustworthy than the filename.
+  if [ -d backups ]; then
+    ls -1 backups/ingest-*.sqlite 2>/dev/null | sort -r | tail -n +6 |
+      while read -r f; do rm -f \"\$f\" && echo \"   removed \$f\"; done
+  fi
+"
+
 echo "✅ Published to $REMOTE:$REMOTE_DIR"
 echo "   Restart the daemon so it serves the new release:"
 echo "   NFSN panel → Daemons → Send Signals → TERM (it relaunches)."

--- a/shared/src/publish.test.ts
+++ b/shared/src/publish.test.ts
@@ -146,7 +146,8 @@ describe('publishToStorage', () => {
       'hash2',
     ]);
 
-    // latest pointer + slim DB present, embeddings stripped.
+    // latest pointer + slim DB present, clustering embeddings stripped but the
+    // tag embeddings the server searches on kept.
     const version = (await storage.get(KEYS.dbLatest())).toString();
     expect(version).toBe('2026-06-15T00-00-00Z');
 
@@ -160,9 +161,12 @@ describe('publishToStorage', () => {
       .prepare('SELECT tags_embedding AS e, tags FROM photos WHERE uuid = ?')
       .get('u1') as { e: Buffer | null; tags: string };
     slim.close();
-    expect(faceRow.n).toBe(0); // embedding emptied
-    expect(tagRow.e).toBeNull(); // tags_embedding nulled
-    expect(tagRow.tags).toBe('beach, sun'); // but tags (cheap, useful) kept
+    expect(faceRow.n).toBe(0); // clustering embedding emptied (offline-only)
+    // tags_embedding is the server's search index — stripping it made every
+    // content search silently return zero hits in prod.
+    expect(tagRow.e).not.toBeNull();
+    expect(tagRow.e?.byteLength).toBe(f32(0.1, 0.2).byteLength);
+    expect(tagRow.tags).toBe('beach, sun');
 
     // Republishing archives the previous fat DB instead of clobbering it.
     const second = await publishToStorage({

--- a/shared/src/publish.ts
+++ b/shared/src/publish.ts
@@ -117,6 +117,7 @@ export async function publishToStorage(
       photos: allPhotos.length,
       faces: allFaces.length,
       dogs: allDogs.length,
+      tagsEmbeddings: allPhotos.filter((p) => p.tagsEmbedding != null).length,
     });
 
     // 2. Non-destructive uploads: labels, then the immutable slim snapshot.
@@ -247,11 +248,21 @@ function assertIntegrity(dbPath: string): void {
 }
 
 /** Abort before cutover unless the slim snapshot's row counts match the fat DB
- * exactly — slim is a byte copy with only the embedding columns emptied, so any
- * mismatch (or a zero-photo library) means the copy is bad. */
+ * exactly — slim is a byte copy with only the clustering embeddings emptied, so
+ * any mismatch (or a zero-photo library) means the copy is bad.
+ *
+ * Also asserts the slim DB retains as many tags_embedding rows as the fat one.
+ * Stripping them yields a snapshot that serves photos correctly but silently
+ * returns nothing for every textual search, which is invisible until someone
+ * searches in prod. */
 function verifySlim(
   slimPath: string,
-  expected: { photos: number; faces: number; dogs: number },
+  expected: {
+    photos: number;
+    faces: number;
+    dogs: number;
+    tagsEmbeddings: number;
+  },
 ): void {
   const sqlite = new Database(slimPath, { readonly: true });
   try {
@@ -262,8 +273,13 @@ function verifySlim(
       photos: count('photos'),
       faces: count('faces'),
       dogs: count('dogs'),
+      tagsEmbeddings: (
+        sqlite
+          .prepare('SELECT count(tags_embedding) AS n FROM photos')
+          .get() as { n: number }
+      ).n,
     };
-    for (const key of ['photos', 'faces', 'dogs'] as const) {
+    for (const key of ['photos', 'faces', 'dogs', 'tagsEmbeddings'] as const) {
       if (got[key] !== expected[key]) {
         throw new Error(
           `Refusing to publish: slim DB ${key} count ${got[key]} != fat ${expected[key]}.`,
@@ -278,9 +294,14 @@ function verifySlim(
   }
 }
 
-/** Copy the DB and strip embeddings (the bulk), then VACUUM to reclaim space.
- * Embedding columns are NOT NULL, so they're emptied rather than dropped —
- * the serving schema stays identical, only the heavy bytes go. */
+/** Copy the DB and strip the clustering embeddings (the bulk), then VACUUM to
+ * reclaim space. Those columns are NOT NULL, so they're emptied rather than
+ * dropped — the serving schema stays identical, only the heavy bytes go.
+ *
+ * photos.tags_embedding is deliberately KEPT: the server's textual image search
+ * loads it at runtime to score queries, and there is no other copy in the slim
+ * DB to rebuild it from. faces/dogs embeddings are only consumed offline by
+ * clustering, so they stay stripped. */
 function buildSlimDb(dbPath: string): string {
   const slimPath = path.join(
     os.tmpdir(),
@@ -291,7 +312,6 @@ function buildSlimDb(dbPath: string): string {
   try {
     sqlite.exec("UPDATE faces SET embedding = X''");
     sqlite.exec("UPDATE dogs SET embedding = X''");
-    sqlite.exec('UPDATE photos SET tags_embedding = NULL');
     sqlite.exec('VACUUM');
   } finally {
     sqlite.close();


### PR DESCRIPTION
Textual image search has been returning zero results in prod for every query, even though all 27k photos were analyzed. Two independent causes, both silent — the server answered `200 OK` with an empty list, which looks like "no matches" rather than a failure.

1. **The publish step deleted the search index.** The slim serving DB stripped `photos.tags_embedding` along with the faces/dogs clustering embeddings — but that column *is* what search ranks against at runtime, and the slim DB has no other copy to rebuild it from. The tags were there; the vectors weren't. Faces/dogs embeddings are offline-only and stay stripped.

2. **The query embedder was never deployed.** Its model directory resolved against the cwd, but the daemon runs node without `cd`'ing and the deploy never shipped a `models/` dir. It now comes from `MODEL_CACHE_DIR` in `.env` — mirroring how `config.ts` already loads `.env` by path — and the model is rsynced to the host.

Also included:

- `verifySlim` now asserts the tag embeddings survived a publish. It only compared row counts, which don't change when a column is nulled in place, so it would have passed a fully-stripped DB forever.
- The host no longer accumulates DB artifacts without bound. Local pruning never propagated because the push is additive, so fat-DB archives grew ~224MB per publish.
- The setup wizard's model-host prompt now says it expects a URL, instead of rejecting a typed phrase with `Can't reach This computer`.

Verified end-to-end against the real 27k-photo library: a slim DB built under the new rules loads 27,231 embeddings and returns sensible hits (`"dog on a beach"` → corgi-on-pebble-beach). The prune logic was tested against a fixture of the real host layout under `/bin/sh`.

## Key Concerns

- **`MODEL_CACHE_DIR` is now required**, so an existing `.env` would fail boot. `migrateConfig` back-fills it (same pattern as the existing `VISION_SERVER_HOST` back-fill), and the deploy regenerates prod's `.env`. Worth a look that no config path is missed.
- **The served DB grows ~28MB → ~68MB.** That's the embeddings returning; unavoidable without a separate index.
- **The prune runs `rm` on the host.** It deliberately never touches `db/ingest.sqlite` — `pull.sh` restores a wiped machine from it, so the host is that file's offsite copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)