### PR TITLE
Fix mobile grid scrolling, add photo download

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Your Own Gallery",
     "slug": "your-own-gallery",
-    "version": "1.2.0",
+    "version": "1.5.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "yourowngallery",
@@ -25,6 +25,13 @@
     "plugins": [
       "expo-router",
       [
+        "expo-media-library",
+        {
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos you download from your gallery.",
+          "isAccessMediaLocationEnabled": false
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "backgroundColor": "#208AEF",
@@ -33,7 +40,8 @@
             "imageWidth": 76
           }
         }
-      ]
+      ],
+      "expo-sharing"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "main": "expo-router/entry",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",
@@ -9,9 +9,12 @@
     "@tamagui/config": "^2.0.0",
     "expo": "^56.0.12",
     "expo-constants": "~56.0.15",
+    "expo-file-system": "~56.0.8",
     "expo-image": "~56.0.9",
     "expo-linking": "~56.0.11",
+    "expo-media-library": "~56.0.9",
     "expo-router": "~56.2.6",
+    "expo-sharing": "~56.0.22",
     "expo-splash-screen": "^56.0.10",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/frontend/src/components/PhotoGrid.tsx
+++ b/frontend/src/components/PhotoGrid.tsx
@@ -293,7 +293,15 @@ function PhotoGrid({
   );
 
   if (!isMobile || !onColumnCountChange) return list;
-  return <GestureDetector gesture={pinchGesture}>{list}</GestureDetector>;
+  // touchAction is web-only and essential here: gesture-handler otherwise sets
+  // `touch-action: none` on the wrapper, which tells mobile browsers to stop
+  // handling pans — killing scroll for the whole grid. `pan-y` keeps vertical
+  // scrolling native while pointer events still reach the pinch handler.
+  return (
+    <GestureDetector gesture={pinchGesture} touchAction="pan-y">
+      {list}
+    </GestureDetector>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/frontend/src/components/PhotoViewer.tsx
+++ b/frontend/src/components/PhotoViewer.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 import {
+  ActivityIndicator,
   Modal,
   Platform,
   Pressable,
@@ -35,6 +36,7 @@ import Animated, {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { apiFetch, imageUrl, thumbnailUrl } from '../lib/api';
+import { downloadPhoto } from '../lib/download';
 import type { Photo } from '../lib/types';
 import { FONT_SIZES, SPACING } from '../styles/styleConsts';
 import type { Palette } from '../styles/usePalette';
@@ -136,6 +138,8 @@ export default function PhotoViewer({
     before: [],
     after: [],
   });
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   const currentIndex = useMemo(
     () => (photo ? photos.findIndex((p) => p.id === photo.id) : -1),
@@ -158,6 +162,26 @@ export default function PhotoViewer({
     },
     [inResults, neighbors, onNavigate, onSelectPhoto, photo],
   );
+
+  // A failure belongs to the photo it happened on — don't carry it forward.
+  useEffect(() => {
+    setDownloadError(null);
+  }, [photo?.id]);
+
+  const handleDownload = useCallback(async () => {
+    if (!photo || downloading) return;
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      await downloadPhoto(photo);
+    } catch (err) {
+      setDownloadError(
+        err instanceof Error ? err.message : 'Could not download this photo',
+      );
+    } finally {
+      setDownloading(false);
+    }
+  }, [downloading, photo]);
 
   // Slide animation state. The image area is a three-slot filmstrip —
   // [prev, current, next] — laid out side by side and translated as one track,
@@ -516,6 +540,15 @@ export default function PhotoViewer({
             )}
           </View>
 
+          {downloadError && (
+            <Text
+              style={[styles.downloadError, { color: palette.error }]}
+              numberOfLines={2}
+            >
+              {downloadError}
+            </Text>
+          )}
+
           {/* Bottom bar: flush and in-flow — floating overlapped the mobile
               neighbors/metadata panels, which live at the bottom too. */}
           <View
@@ -574,6 +607,23 @@ export default function PhotoViewer({
               palette={palette}
               title={showMetadata ? 'Hide metadata' : 'Show metadata'}
             />
+            <View
+              style={[styles.divider, { backgroundColor: palette.divider }]}
+            />
+            <IconBtn
+              name="file-download"
+              onPress={handleDownload}
+              disabled={downloading}
+              busy={downloading}
+              palette={palette}
+              title={
+                downloading
+                  ? 'Downloading…'
+                  : Platform.OS === 'web'
+                    ? 'Download original'
+                    : 'Save to Photos'
+              }
+            />
           </View>
         </SafeAreaView>
       </GestureHandlerRootView>
@@ -590,6 +640,7 @@ function IconBtn({
   onPress,
   disabled,
   active,
+  busy,
   palette,
   title,
 }: {
@@ -597,6 +648,7 @@ function IconBtn({
   onPress: () => void;
   disabled?: boolean;
   active?: boolean;
+  busy?: boolean;
   palette: Palette;
   title: string;
 }) {
@@ -616,7 +668,11 @@ function IconBtn({
           { opacity: disabled ? 0.4 : pressed ? 0.6 : 1 },
         ]}
       >
-        <MaterialIcons name={name} size={24} color={color} />
+        {busy ? (
+          <ActivityIndicator size="small" color={color} />
+        ) : (
+          <MaterialIcons name={name} size={24} color={color} />
+        )}
       </Pressable>
     </Tooltip>
   );
@@ -969,6 +1025,12 @@ const styles = StyleSheet.create({
     width: 1,
     height: 24,
     marginHorizontal: SPACING.SMALL,
+  },
+  downloadError: {
+    paddingHorizontal: SPACING.MEDIUM,
+    paddingBottom: SPACING.TINY,
+    fontSize: FONT_SIZES.SMALL,
+    textAlign: 'center',
   },
   neighborsScroll: {
     flexShrink: 0,

--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,0 +1,74 @@
+import { File, Paths } from 'expo-file-system';
+import * as MediaLibrary from 'expo-media-library';
+import * as Sharing from 'expo-sharing';
+import { Platform } from 'react-native';
+
+import { imageUrl } from './api';
+import type { Photo } from './types';
+
+/** `originalPath` is a bare filename, but guard against stray path segments. */
+function fileNameFor(photo: Photo): string {
+  const base = photo.originalPath.split('/').pop();
+  return base && base.length > 0 ? base : `photo-${photo.id}.jpg`;
+}
+
+async function shareFallback(uri: string): Promise<void> {
+  if (!(await Sharing.isAvailableAsync())) {
+    throw new Error('Could not save this photo');
+  }
+  await Sharing.shareAsync(uri);
+}
+
+/**
+ * Save the full-resolution original.
+ *
+ * Web: fetched as a blob rather than pointed at with a plain `<a download>`,
+ * because in local dev the backend is a different origin — browsers ignore the
+ * download attribute cross-origin and navigate to the image instead.
+ *
+ * Native: `/images` sits behind the session cookie, which iOS's shared cookie
+ * storage attaches to the download for us. The file lands in the cache
+ * directory (system-reclaimable) and is then added to the photo library.
+ *
+ * Falls back to the share sheet whenever the library can't take it — the user
+ * declined the permission prompt, or the original is a format Photos rejects
+ * (raw/TIFF originals do exist in this library). The share sheet always has
+ * somewhere to put the file, so a fallback beats an error.
+ */
+export async function downloadPhoto(photo: Photo): Promise<void> {
+  const url = imageUrl(photo.originalPath);
+  const name = fileNameFor(photo);
+
+  if (Platform.OS === 'web') {
+    const res = await fetch(url, { credentials: 'include' });
+    if (!res.ok) throw new Error(`Download failed (${res.status})`);
+    const blob = await res.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = name;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(objectUrl);
+    return;
+  }
+
+  const file = await File.downloadFileAsync(url, new File(Paths.cache, name), {
+    idempotent: true,
+  });
+
+  // writeOnly: adding to the library never needs to read the user's photos, and
+  // the write-only prompt is the less alarming one.
+  const permission = await MediaLibrary.requestPermissionsAsync(true);
+  if (!permission.granted) {
+    await shareFallback(file.uri);
+    return;
+  }
+
+  try {
+    await MediaLibrary.Asset.create(file.uri);
+  } catch {
+    await shareFallback(file.uri);
+  }
+}

--- a/line-count.sh
+++ b/line-count.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+
+# Directories to ignore (space-separated)
+IGNORE_DIRS="node_modules dist dist-web dist-native build .git frontend/ios frontend/android explorations"
+
+# Extensions to ignore (space-separated, no leading dot)
+IGNORE_EXTS="csv jpg png gif svg mp4 mp3 zip gz tar lock ttf woff woff2 xml jar webp json"
+
+# Filenames to ignore (space-separated, no paths)
+IGNORE_FILES="package-lock.json"
+
+# Build the exclude pattern for grep
+EXCLUDE_PATTERN=""
+for d in $IGNORE_DIRS; do
+  EXCLUDE_PATTERN="$EXCLUDE_PATTERN|^$d/"
+done
+for e in $IGNORE_EXTS; do
+  EXCLUDE_PATTERN="$EXCLUDE_PATTERN|\\.$e\$"
+done
+for f in $IGNORE_FILES; do
+  EXCLUDE_PATTERN="$EXCLUDE_PATTERN|/$(echo "$f" | sed 's/\./\\./g')\$"
+done
+EXCLUDE_PATTERN="${EXCLUDE_PATTERN#|}"
+
+# Get tracked files, filter out ignores
+FILES=$(git ls-files | grep -Ev "$EXCLUDE_PATTERN")
+
+# Count lines per extension
+raw_counts=$(
+  for f in $FILES; do
+    if [ -f "$f" ]; then
+      base=$(basename "$f")
+      ext="${base##*.}"
+
+      # Must have a dot that's not the first char, and not equal to basename
+      if [ "$ext" != "$base" ] && [ "${base%.*}" != "" ]; then
+        lines=$(wc -l < "$f")
+        echo "$ext $lines"
+      fi
+    fi
+  done | awk '
+    { count[$1]+=$2; total+=$2 }
+    END {
+      for (e in count) print e, count[e]
+      print "TOTAL", total
+    }'
+)
+
+# Function for adding commas
+add_commas() {
+  echo "$1" | awk '{
+    n=$1
+    s=""
+    while (n >= 1000) {
+      s = sprintf(",%03d", n % 1000) s
+      n = int(n / 1000)
+    }
+    s = n s
+    print s
+  }'
+}
+
+# Format numbers with commas
+formatted_counts=$(
+  echo "$raw_counts" | while read -r ext num; do
+    numfmt=$(add_commas "$num")
+    echo "$ext $numfmt"
+  done
+)
+
+# Calculate widths including TOTAL line
+maxext=$(echo "$formatted_counts" | awk '{ if(length($1)>m) m=length($1)} END{print m}')
+maxnum=$(echo "$formatted_counts" | awk '{ if(length($2)>m) m=length($2)} END{print m}')
+
+# Print sorted extensions (excluding TOTAL)
+echo "$formatted_counts" | grep -v '^TOTAL' | sort | \
+  awk -v maxext="$maxext" -v maxnum="$maxnum" \
+  '{ printf "%-"maxext"s % "maxnum"s\n", $1, $2 }'
+
+# Separator
+dashlen=$((maxext + 1 + maxnum))
+printf '%*s\n' "$dashlen" '' | tr ' ' '-'
+
+# Print TOTAL with same alignment
+echo "$formatted_counts" | grep '^TOTAL' | \
+  awk -v maxext="$maxext" -v maxnum="$maxnum" \
+  '{ printf "%-"maxext"s % "maxnum"s\n", $1, $2 }'

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
       }
     },
     "frontend": {
-      "version": "1.0.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
@@ -93,9 +93,12 @@
         "@tamagui/config": "^2.0.0",
         "expo": "^56.0.12",
         "expo-constants": "~56.0.15",
+        "expo-file-system": "~56.0.8",
         "expo-image": "~56.0.9",
         "expo-linking": "~56.0.11",
+        "expo-media-library": "~56.0.9",
         "expo-router": "~56.2.6",
+        "expo-sharing": "~56.0.22",
         "expo-splash-screen": "^56.0.10",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -16083,6 +16086,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "56.0.9",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-56.0.9.tgz",
+      "integrity": "sha512-SD92CiE/UPXpDmvSrOWtMX12TeGhN4w9ZdePNNxa43bC9uTnEAS3YTLAkNaFHHbCSUlWSNVLW4yPZhNgugAO/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "56.0.16",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-56.0.16.tgz",
@@ -16283,6 +16296,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "56.0.22",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-56.0.22.tgz",
+      "integrity": "sha512-r2lt8sJUbEi6O1DIK192GEk6JayBEQNjfTvJ3iHzW//5dUy20NCaLSKFeE2z+DE+lVzu5izOocWRwIbbubywvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-plugins": "^56.0.13",
+        "@expo/config-types": "^56.0.7",
+        "@expo/plist": "^0.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-plugins": {
+      "version": "56.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.13.tgz",
+      "integrity": "sha512-BWtRkvUKLb4xaMLTRXmrHPHl+RI5nKF2MKJEXODHmLtVgUlXOz66XSCU4bEvjfr8yYTx+8DQ0JO54Y7Y0kwokA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^56.0.7",
+        "@expo/json-file": "~10.2.0",
+        "@expo/plist": "^0.7.0",
+        "@expo/require-utils": "^56.1.5",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "semver": "^7.5.4",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/config-types": {
+      "version": "56.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.7.tgz",
+      "integrity": "sha512-V7bxawNsNned/yMppAHdisIOxniZXgPKRWpIUiQOQBs45/A5MBd2gfDM4Ecq5gnbilnQUTaI6Zxn6JcW7L3TAA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-sharing/node_modules/@expo/json-file": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/plist": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
+      "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@expo/require-utils": {
+      "version": "56.1.5",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.5.tgz",
+      "integrity": "sha512-3wsdJLSpELhRPEMZCCREqAAFRGG23BUWJHGKIUxyqGkWvy5KPdzlBxGlVVb/6h9gNOflqgTtvTWaP2EuHoQ1HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-sharing/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-sharing/node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/expo-splash-screen": {


### PR DESCRIPTION
The photo grid could not be scrolled at all on a phone — the pinch-to-zoom wrapper (mobile-only) told the browser to stop handling pans. Vertical scrolling is native again, and pinch-to-zoom still works. Desktop was never affected.

Individual photos can now be saved from the viewer's bottom bar:

- Web downloads the full-resolution original.
- iOS saves it into the photo library, falling back to the share sheet if the permission is declined or Photos won't take the format.

Also bumps the app to 1.5.0 and commits `line-count.sh`, which had never been tracked (now ignoring json).

## Key Concerns

- Adds three native modules (`expo-file-system`, `expo-media-library`, `expo-sharing`), so this needs a fresh native build — it cannot ship over the air.
- Saving to Photos introduces a photo-library permission prompt on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)