### PR TITLE
Skip collapsed sections while loading, add ISO/aperture/camera sorts

### DIFF
--- a/backend/src/routes/photos.sections.test.ts
+++ b/backend/src/routes/photos.sections.test.ts
@@ -1,0 +1,244 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { asc, desc, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { photos } from 'shared/db/schema';
+import { buildFilterConditions, querySections } from './photos.js';
+
+// In-memory SQLite for testing
+let sqlite: InstanceType<typeof Database>;
+let db: ReturnType<typeof drizzle>;
+
+type QueryDb = Parameters<typeof querySections>[0];
+
+function seedPhotos() {
+  const base = {
+    blurhash: 'LEHV6nWB',
+    width: 6000,
+    height: 4000,
+    aspectRatio: 1.5,
+    lens: 'NIKKOR Z 50mm f/1.8 S',
+    shutterSpeed: '1/250',
+    focalLength: 50,
+    keywords: '["landscape"]',
+    fileSize: 12000000,
+    mimeType: 'image/jpeg',
+  };
+  const rows = [
+    {
+      uuid: 'aaa-111',
+      filename: 'sunset.jpg',
+      camera: 'NIKON Z 6_2',
+      dateCaptured: new Date('2024-01-15T10:30:00Z'),
+      iso: 200,
+      aperture: 1.8,
+      rating: 4,
+    },
+    {
+      uuid: 'bbb-222',
+      filename: 'city.jpg',
+      camera: 'Canon EOS R6',
+      dateCaptured: new Date('2024-03-22T18:45:00Z'),
+      iso: 800,
+      aperture: 2.8,
+      rating: 3,
+    },
+    {
+      uuid: 'ccc-333',
+      filename: 'portrait.jpg',
+      camera: 'NIKON Z 6_2',
+      dateCaptured: new Date('2024-01-24T14:00:00Z'),
+      iso: 100,
+      aperture: 1.8,
+      rating: 5,
+    },
+    {
+      uuid: 'ddd-444',
+      filename: 'Food.jpg',
+      camera: 'Canon EOS R6',
+      dateCaptured: new Date('2024-06-15T12:00:00Z'),
+      iso: 400,
+      aperture: 5.6,
+      rating: null,
+    },
+    // No EXIF: exercises NULL group placement (first asc, last desc)
+    {
+      uuid: 'eee-555',
+      filename: 'scan.jpg',
+      camera: null,
+      dateCaptured: null,
+      iso: null,
+      aperture: null,
+      rating: null,
+    },
+  ];
+  for (const row of rows) {
+    db.insert(photos)
+      .values({
+        ...base,
+        ...row,
+        originalPath: `/images/${row.uuid}.jpg`,
+        thumbnailPath: `/thumbnails/${row.uuid}.jpg`,
+      })
+      .run();
+  }
+}
+
+beforeAll(() => {
+  sqlite = new Database(':memory:');
+  db = drizzle(sqlite);
+
+  const migrationsFolder = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../drizzle',
+  );
+  migrate(db, { migrationsFolder });
+
+  seedPhotos();
+});
+
+afterAll(() => {
+  sqlite.close();
+});
+
+describe('querySections', () => {
+  it('groups date sorts by month, newest first for desc', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'dateCaptured',
+      'desc',
+      undefined,
+    );
+    expect(sections).toEqual([
+      { key: '2024-06', count: 1 },
+      { key: '2024-03', count: 1 },
+      { key: '2024-01', count: 2 },
+      { key: null, count: 1 },
+    ]);
+  });
+
+  it('places the NULL group first for asc, matching SQLite NULL ordering', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'dateCaptured',
+      'asc',
+      undefined,
+    );
+    expect(sections.map((s) => s.key)).toEqual([
+      null,
+      '2024-01',
+      '2024-03',
+      '2024-06',
+    ]);
+  });
+
+  it('groups by raw value for iso', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'iso',
+      'asc',
+      undefined,
+    );
+    expect(sections).toEqual([
+      { key: null, count: 1 },
+      { key: 100, count: 1 },
+      { key: 200, count: 1 },
+      { key: 400, count: 1 },
+      { key: 800, count: 1 },
+    ]);
+  });
+
+  it('groups by camera name', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'camera',
+      'asc',
+      undefined,
+    );
+    expect(sections).toEqual([
+      { key: null, count: 1 },
+      { key: 'Canon EOS R6', count: 2 },
+      { key: 'NIKON Z 6_2', count: 2 },
+    ]);
+  });
+
+  it('groups filename by uppercased first letter', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'filename',
+      'asc',
+      undefined,
+    );
+    expect(sections).toEqual([
+      { key: 'C', count: 1 },
+      { key: 'F', count: 1 },
+      { key: 'P', count: 1 },
+      { key: 'S', count: 2 },
+    ]);
+  });
+
+  it('returns a single section for ungrouped sorts (rating)', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'rating',
+      'desc',
+      undefined,
+    );
+    expect(sections).toEqual([{ key: null, count: 5 }]);
+  });
+
+  it('respects filter conditions', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'dateCaptured',
+      'desc',
+      buildFilterConditions({ camera: 'NIKON Z 6_2' }),
+    );
+    expect(sections).toEqual([{ key: '2024-01', count: 2 }]);
+  });
+
+  it('stays in lockstep with the photo query order', async () => {
+    // The client walks /photos results and assigns each photo to a section;
+    // skip-ahead offsets are only correct if the section outline lists groups
+    // in exactly the order (and with the counts) the photo stream produces.
+    for (const sortOrder of ['asc', 'desc'] as const) {
+      const orderFn = sortOrder === 'asc' ? asc : desc;
+      const rows = db
+        .select({ dateCaptured: photos.dateCaptured })
+        .from(photos)
+        .orderBy(orderFn(photos.dateCaptured), asc(photos.id))
+        .all();
+
+      const walked: { key: string | null; count: number }[] = [];
+      for (const row of rows) {
+        const key = row.dateCaptured
+          ? row.dateCaptured.toISOString().substring(0, 7)
+          : null;
+        const last = walked[walked.length - 1];
+        if (last && last.key === key) last.count += 1;
+        else walked.push({ key, count: 1 });
+      }
+
+      const sections = await querySections(
+        db as unknown as QueryDb,
+        'dateCaptured',
+        sortOrder,
+        undefined,
+      );
+      expect(sections).toEqual(walked);
+    }
+  });
+
+  it('returns no sections when nothing matches', async () => {
+    const sections = await querySections(
+      db as unknown as QueryDb,
+      'rating',
+      'desc',
+      sql`1 = 0`,
+    );
+    expect(sections).toEqual([]);
+  });
+});

--- a/backend/src/routes/photos.ts
+++ b/backend/src/routes/photos.ts
@@ -287,6 +287,25 @@ export function buildFilterConditions(filters: {
   return and(...conditions);
 }
 
+/**
+ * Sort expression per sortBy value. Filename sorts case-insensitively so the
+ * grid's first-letter sections (which uppercase the letter) stay contiguous —
+ * under binary collation 'B1.jpg' < 'a2.jpg' < 'b3.jpg' would interleave the
+ * A and B sections.
+ */
+function sortColumn(sortBy: string): AnyColumn | SQL {
+  const columns: Record<string, AnyColumn | SQL> = {
+    dateCaptured: photos.dateCaptured,
+    filename: sql`${photos.filename} COLLATE NOCASE`,
+    rating: photos.rating,
+    createdAt: photos.createdAt,
+    iso: photos.iso,
+    aperture: photos.aperture,
+    camera: photos.camera,
+  };
+  return columns[sortBy] ?? photos.dateCaptured;
+}
+
 // In-memory metadata cache
 let metadataCache: {
   data: Record<string, unknown>;
@@ -314,13 +333,14 @@ router.get('/photos', async (req, res) => {
     const {
       page: pageNum,
       limit: limitNum,
+      offset: offsetParam,
       sortBy,
       sortOrder,
       contentSearch,
       ...filterParams
     } = parsed.data;
 
-    const offset = (pageNum - 1) * limitNum;
+    const offset = offsetParam ?? (pageNum - 1) * limitNum;
 
     if (contentSearch && contentSearch.length > 0) {
       // Filter-first, rank-second: apply non-content filters in SQL to get a
@@ -402,7 +422,7 @@ router.get('/photos', async (req, res) => {
           limit: limitNum,
           total,
           totalPages: Math.ceil(total / limitNum),
-          hasMore: pageNum * limitNum < total,
+          hasMore: offset + paginated.length < total,
         },
       });
       return;
@@ -410,15 +430,8 @@ router.get('/photos', async (req, res) => {
 
     const whereClause = buildFilterConditions(filterParams);
 
-    // Determine sort column and order
-    const validSortColumns: Record<string, AnyColumn> = {
-      dateCaptured: photos.dateCaptured,
-      filename: photos.filename,
-      rating: photos.rating,
-      createdAt: photos.createdAt,
-    };
     const orderFn = sortOrder === 'asc' ? asc : desc;
-    const orderByColumn = validSortColumns[sortBy] ?? photos.dateCaptured;
+    const orderByColumn = sortColumn(sortBy);
 
     // Execute query with window function to get total count in a single pass.
     // The id tiebreaker makes the order deterministic across page fetches AND
@@ -447,12 +460,90 @@ router.get('/photos', async (req, res) => {
         limit: limitNum,
         total,
         totalPages: Math.ceil(total / limitNum),
-        hasMore: pageNum * limitNum < total,
+        hasMore: offset + allPhotos.length < total,
       },
     });
   } catch (error) {
     console.error('Error fetching photos:', error);
     res.status(500).json({ error: 'Failed to fetch photos' });
+  }
+});
+
+// Section outline for the current filters + sort: every group the grid will
+// render, in the exact order /photos emits photos, with per-group counts.
+// The client uses the cumulative counts as offsets to skip collapsed sections
+// instead of paging through them. Group keys mirror the frontend's
+// groupPhotosBySort: months for date sorts, raw values otherwise.
+export async function querySections(
+  dbConn: typeof db,
+  sortBy: string,
+  sortOrder: 'asc' | 'desc',
+  whereClause: SQL | undefined,
+): Promise<{ key: string | number | null; count: number }[]> {
+  const groupExprs: Record<string, SQL> = {
+    dateCaptured: sql`strftime('%Y-%m', ${photos.dateCaptured}, 'unixepoch')`,
+    createdAt: sql`strftime('%Y-%m', ${photos.createdAt}, 'unixepoch')`,
+    iso: sql`${photos.iso}`,
+    aperture: sql`${photos.aperture}`,
+    camera: sql`${photos.camera}`,
+    filename: sql`upper(substr(${photos.filename}, 1, 1))`,
+  };
+  const groupExpr = groupExprs[sortBy];
+
+  if (!groupExpr) {
+    // Ungrouped sorts (rating): the grid shows a single section.
+    const [row] = await dbConn
+      .select({ count: sql<number>`count(*)` })
+      .from(photos)
+      .where(whereClause);
+    return row.count > 0 ? [{ key: null, count: row.count }] : [];
+  }
+
+  // Ordering by the group key matches photo order because every key is a
+  // monotonic function of its sort column, and SQLite places NULL keys
+  // exactly where it places NULL sort values (first asc, last desc).
+  const orderFn = sortOrder === 'asc' ? asc : desc;
+  return dbConn
+    .select({
+      key: sql<string | number | null>`${groupExpr}`,
+      count: sql<number>`count(*)`,
+    })
+    .from(photos)
+    .where(whereClause)
+    .groupBy(groupExpr)
+    .orderBy(orderFn(groupExpr));
+}
+
+router.get('/photos/sections', async (req, res) => {
+  try {
+    const parsed = photoFiltersSchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Invalid query parameters',
+        details: parsed.error.flatten(),
+      });
+      return;
+    }
+    const {
+      page: _page,
+      limit: _limit,
+      offset: _offset,
+      sortBy,
+      sortOrder,
+      contentSearch: _contentSearch,
+      ...filterParams
+    } = parsed.data;
+
+    const sections = await querySections(
+      db,
+      sortBy,
+      sortOrder,
+      buildFilterConditions(filterParams),
+    );
+    res.json({ sections });
+  } catch (error) {
+    console.error('Error fetching sections:', error);
+    res.status(500).json({ error: 'Failed to fetch sections' });
   }
 });
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Your Own Gallery",
     "slug": "your-own-gallery",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "yourowngallery",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "main": "expo-router/entry",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -32,9 +32,15 @@ import {
   setColumnCount,
   useSetting,
 } from '../lib/settings';
-import type { Photo, PhotoFilters, PhotosResponse } from '../lib/types';
+import type {
+  Photo,
+  PhotoFilters,
+  PhotosResponse,
+  SectionsResponse,
+} from '../lib/types';
 import { SPACING } from '../styles/styleConsts';
 import { useTheme } from '../styles/useTheme';
+import { getGroupKey, normalizeSectionKey } from '../utils/groupPhotos';
 
 const PAGE_SIZE = 100;
 
@@ -55,13 +61,18 @@ const DEFAULT_FILTERS: PhotoFilters = {
 
 function buildQueryString(
   filters: PhotoFilters,
-  page: number,
+  target: { page?: number; offset?: number },
   limit: number,
 ): string {
   const params = new URLSearchParams({
-    page: String(page),
+    page: String(target.page ?? 1),
     limit: String(limit),
   });
+  // Absolute row offset (overrides page server-side) — used to skip past
+  // collapsed sections instead of paging through them.
+  if (target.offset !== undefined) {
+    params.set('offset', String(target.offset));
+  }
   for (const [k, v] of Object.entries(filters)) {
     if (v !== undefined && v !== null && v !== '') {
       params.append(k, String(v));
@@ -79,6 +90,19 @@ export default function HomeScreen() {
   const [photos, setPhotos] = useState<Photo[]>([]);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  // Section outline for the active grouping (keys + total counts, in display
+  // order) from /photos/sections. Cumulative counts double as row offsets, so
+  // loading can jump over collapsed sections. Tagged with the filters that
+  // produced it so a stale outline is never paired with mismatched photos.
+  // null → endpoint unavailable or grouping inactive; loading falls back to
+  // plain page-append.
+  const [sections, setSections] = useState<{
+    forKey: string;
+    list: { key: string; count: number }[];
+  } | null>(null);
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
+    new Set(),
+  );
   const [loading, setLoading] = useState(false);
   // True while replacing the result set (filter/search change) as opposed to
   // appending a page — drives the grid's refresh veil.
@@ -131,9 +155,25 @@ export default function HomeScreen() {
   const [displayedSortBy, setDisplayedSortBy] = useState<string | undefined>(
     () => groupingFor(DEFAULT_FILTERS),
   );
+  // Filters (as a JSON key) that produced the photos currently displayed —
+  // pairs the section outline with the right photo set during transitions.
+  const [displayedKey, setDisplayedKey] = useState(() =>
+    JSON.stringify(DEFAULT_FILTERS),
+  );
+
+  // Set when a skip-offset fetch produced nothing new (section metadata
+  // drifted from the photo query). Blocks re-requesting the same offset
+  // forever; cleared on any filter change.
+  const stallOffsetRef = useRef<number | null>(null);
+  // Section key just expanded — triggers a backfill fetch for its gap.
+  const expandedKeyRef = useRef<string | null>(null);
 
   const fetchPhotos = useCallback(
-    async (pageNum: number, currentFilters: PhotoFilters, append: boolean) => {
+    async (
+      target: { page?: number; offset?: number },
+      currentFilters: PhotoFilters,
+      append: boolean,
+    ) => {
       if (append && loadingRef.current) return;
       if (!append && abortRef.current) abortRef.current.abort();
       const ac = new AbortController();
@@ -145,18 +185,24 @@ export default function HomeScreen() {
       if (!append) setRefreshing(true);
       setError(null);
       try {
-        const qs = buildQueryString(currentFilters, pageNum, PAGE_SIZE);
+        const qs = buildQueryString(currentFilters, target, PAGE_SIZE);
         const response = await apiFetch(`/api/photos?${qs}`, {
           signal: ac.signal,
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data: PhotosResponse = await response.json();
         if (seq !== seqRef.current) return;
-        if (!append) setDisplayedSortBy(groupingFor(currentFilters));
+        if (!append) {
+          setDisplayedSortBy(groupingFor(currentFilters));
+          setDisplayedKey(JSON.stringify(currentFilters));
+        }
         setPhotos((prev) => {
           if (!append) return data.photos;
           const seen = new Set(prev.map((p) => p.id));
           const fresh = data.photos.filter((p) => !seen.has(p.id));
+          if (fresh.length === 0 && target.offset !== undefined) {
+            stallOffsetRef.current = target.offset;
+          }
           return [...prev, ...fresh];
         });
         setHasMore(data.pagination.hasMore);
@@ -179,16 +225,166 @@ export default function HomeScreen() {
   useEffect(() => {
     if (!isAuthenticated) return;
     setPage(1);
-    fetchPhotos(1, filters, false);
+    stallOffsetRef.current = null;
+    fetchPhotos({ page: 1 }, filters, false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, filtersKey, fetchPhotos]);
 
+  // Fetch the section outline alongside page 1. Best-effort: on failure the
+  // grid still works, it just can't skip collapsed sections while loading.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed off filtersKey, same as the photo fetch above
+  useEffect(() => {
+    // Keep any previous outline while this one loads: it still orders the
+    // photos currently on screen (they were fetched under the same filters).
+    if (!isAuthenticated || !groupingFor(filters)) {
+      setSections(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const qs = buildQueryString(filters, {}, PAGE_SIZE);
+        const response = await apiFetch(`/api/photos/sections?${qs}`);
+        if (!response.ok || cancelled) return;
+        const data: SectionsResponse = await response.json();
+        if (cancelled) return;
+        setSections({
+          forKey: filtersKey,
+          list: data.sections.map((s) => ({
+            key: normalizeSectionKey(s.key),
+            count: s.count,
+          })),
+        });
+      } catch {
+        // Ignore — sections are a loading optimization, not required data.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated, filtersKey]);
+
+  // Section keys are sort-specific — clear collapse state when the grouping
+  // of the photos on screen changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: displayedSortBy is the trigger, not an input
+  useEffect(() => {
+    setCollapsedSections(new Set());
+  }, [displayedSortBy]);
+
+  // Outline usable for ordering: it must describe the photos on screen (same
+  // filters produced both), even if newer filters are already in flight.
+  const orderingSections =
+    sections !== null &&
+    sections.forKey === displayedKey &&
+    displayedSortBy !== undefined
+      ? sections.list
+      : null;
+
+  // Outline usable for planning fetches: additionally the displayed photos
+  // must correspond to the CURRENT filters — mixing an outline with photos
+  // from an in-flight filter change would compute bogus skip offsets.
+  const sectionOrder =
+    orderingSections !== null && displayedKey === filtersKey
+      ? orderingSections
+      : null;
+
+  // Photos arrive out of section order once collapsed sections get skipped
+  // and later re-expanded (backfills append last). Re-derive display order
+  // from the section outline; loaded photos within a section are always a
+  // prefix of it, in order, so per-section arrival order is already correct.
+  const { orderedPhotos, loadedCounts } = useMemo(() => {
+    if (!orderingSections || !displayedSortBy) {
+      return { orderedPhotos: photos, loadedCounts: null };
+    }
+    const byKey = new Map<string, Photo[]>();
+    for (const p of photos) {
+      const key = getGroupKey(p, displayedSortBy);
+      const group = byKey.get(key);
+      if (group) group.push(p);
+      else byKey.set(key, [p]);
+    }
+    const ordered: Photo[] = [];
+    const counts = new Map<string, number>();
+    for (const s of orderingSections) {
+      const group = byKey.get(s.key);
+      if (!group) continue;
+      counts.set(s.key, group.length);
+      ordered.push(...group);
+      byKey.delete(s.key);
+    }
+    // Keys missing from the outline shouldn't exist; keep their photos
+    // reachable at the end rather than dropping them.
+    for (const group of byKey.values()) ordered.push(...group);
+    return { orderedPhotos: ordered, loadedCounts: counts };
+  }, [photos, orderingSections, displayedSortBy]);
+
+  // The next row offset the grid needs: the first unloaded photo of the first
+  // expanded, not-fully-loaded section. Collapsed sections advance the offset
+  // by their total count without ever being fetched — this is what lets the
+  // section after a collapsed one load immediately.
+  const nextFetchOffset = useMemo(() => {
+    if (!sectionOrder) return null;
+    let offset = 0;
+    for (const s of sectionOrder) {
+      const loaded = loadedCounts?.get(s.key) ?? 0;
+      if (!collapsedSections.has(s.key) && loaded < s.count) {
+        return offset + loaded;
+      }
+      offset += s.count;
+    }
+    return null;
+  }, [sectionOrder, loadedCounts, collapsedSections]);
+
+  const moreAvailable = sectionOrder
+    ? nextFetchOffset !== null && nextFetchOffset !== stallOffsetRef.current
+    : hasMore;
+
   const handleLoadMore = useCallback(() => {
-    if (!hasMore || loadingRef.current) return;
+    if (loadingRef.current) return;
+    if (sectionOrder) {
+      if (
+        nextFetchOffset === null ||
+        nextFetchOffset === stallOffsetRef.current
+      ) {
+        return;
+      }
+      fetchPhotos({ offset: nextFetchOffset }, filters, true);
+      return;
+    }
+    if (!hasMore) return;
     const next = page + 1;
     setPage(next);
-    fetchPhotos(next, filters, true);
-  }, [hasMore, page, filters, fetchPhotos]);
+    fetchPhotos({ page: next }, filters, true);
+  }, [sectionOrder, nextFetchOffset, hasMore, page, filters, fetchPhotos]);
+
+  const handleToggleSection = useCallback((key: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+        expandedKeyRef.current = key;
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }, []);
+
+  // Re-expanding a section that was skipped while collapsed leaves a gap in
+  // its photos — start filling it right away instead of waiting for a scroll.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: collapsedSections is the trigger, not an input
+  useEffect(() => {
+    const key = expandedKeyRef.current;
+    if (!key || !sectionOrder) return;
+    // A fetch is already in flight — keep the key; this effect re-runs when
+    // the fetch lands (loadedCounts changes) and starts the backfill then.
+    if (loadingRef.current) return;
+    expandedKeyRef.current = null;
+    const meta = sectionOrder.find((s) => s.key === key);
+    const loaded = loadedCounts?.get(key) ?? 0;
+    if (meta && loaded < meta.count) handleLoadMore();
+  }, [collapsedSections, sectionOrder, loadedCounts, handleLoadMore]);
 
   const handlePhotoPress = useCallback((photo: Photo) => {
     setSelectedPhoto(photo);
@@ -203,10 +399,10 @@ export default function HomeScreen() {
   // loaded window and go dead until a page fetch completes. Load ahead while
   // the viewer approaches the boundary instead.
   useEffect(() => {
-    if (!selectedPhoto || !hasMore) return;
-    const idx = photos.findIndex((p) => p.id === selectedPhoto.id);
-    if (idx !== -1 && photos.length - idx <= 20) handleLoadMore();
-  }, [selectedPhoto, photos, hasMore, handleLoadMore]);
+    if (!selectedPhoto || !moreAvailable) return;
+    const idx = orderedPhotos.findIndex((p) => p.id === selectedPhoto.id);
+    if (idx !== -1 && orderedPhotos.length - idx <= 20) handleLoadMore();
+  }, [selectedPhoto, orderedPhotos, moreAvailable, handleLoadMore]);
 
   const handleViewerNavigate = useCallback(
     (direction: 'prev' | 'next') => {
@@ -214,15 +410,15 @@ export default function HomeScreen() {
       // deriving from the latest state (not a closure) keeps every step.
       setSelectedPhoto((current) => {
         if (!current) return current;
-        const idx = photos.findIndex((p) => p.id === current.id);
+        const idx = orderedPhotos.findIndex((p) => p.id === current.id);
         if (idx === -1) return current;
-        if (direction === 'prev' && idx > 0) return photos[idx - 1];
-        if (direction === 'next' && idx < photos.length - 1)
-          return photos[idx + 1];
+        if (direction === 'prev' && idx > 0) return orderedPhotos[idx - 1];
+        if (direction === 'next' && idx < orderedPhotos.length - 1)
+          return orderedPhotos[idx + 1];
         return current;
       });
     },
-    [photos],
+    [orderedPhotos],
   );
 
   const handleFilterChange = useCallback((changed: Partial<PhotoFilters>) => {
@@ -455,11 +651,13 @@ export default function HomeScreen() {
               </View>
             ) : (
               <PhotoGrid
-                photos={photos}
+                photos={orderedPhotos}
                 loading={loading}
-                hasMore={hasMore}
+                hasMore={moreAvailable}
                 columnCount={columnCount}
                 sortBy={displayedSortBy}
+                collapsedSections={collapsedSections}
+                onToggleSection={handleToggleSection}
                 onLoadMore={handleLoadMore}
                 onPhotoPress={handlePhotoPress}
                 onColumnCountChange={setColumnCount}
@@ -485,7 +683,7 @@ export default function HomeScreen() {
 
       <PhotoViewer
         photo={selectedPhoto}
-        photos={photos}
+        photos={orderedPhotos}
         onClose={handleCloseViewer}
         onNavigate={handleViewerNavigate}
         onSelectPhoto={setSelectedPhoto}

--- a/frontend/src/components/PhotoGrid.tsx
+++ b/frontend/src/components/PhotoGrid.tsx
@@ -1,12 +1,5 @@
 import { MaterialIcons } from '@expo/vector-icons';
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -16,6 +9,7 @@ import {
   Text,
   useWindowDimensions,
   View,
+  type ViewToken,
 } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { runOnJS } from 'react-native-reanimated';
@@ -33,6 +27,8 @@ interface PhotoGridProps {
   hasMore: boolean;
   columnCount: number;
   sortBy: string | undefined;
+  collapsedSections: Set<string>;
+  onToggleSection: (key: string) => void;
   onLoadMore: () => void;
   onPhotoPress: (photo: Photo) => void;
   onColumnCountChange?: (count: number) => void;
@@ -111,6 +107,8 @@ function PhotoGrid({
   hasMore,
   columnCount,
   sortBy,
+  collapsedSections,
+  onToggleSection,
   onLoadMore,
   onPhotoPress,
   onColumnCountChange,
@@ -123,21 +121,33 @@ function PhotoGrid({
 
   const listRef = useRef<FlatList<Row>>(null);
 
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  // First row currently in the viewport, tracked so collapsing knows whether
+  // the user is scrolled inside the section being collapsed.
+  const firstVisibleKeyRef = useRef<string | null>(null);
+  const pendingScrollKeyRef = useRef<string | null>(null);
+  const handleViewableItemsChanged = useRef(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      firstVisibleKeyRef.current = viewableItems[0]?.key ?? null;
+    },
+  ).current;
+  const viewabilityConfig = useRef({ viewAreaCoveragePercentThreshold: 0 })
+    .current;
 
-  // Section keys are sort-specific — clear state when the grouping changes.
-  useEffect(() => {
-    setCollapsed(new Set());
-  }, [sortBy]);
-
-  const toggleCollapsed = useCallback((key: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+  const handleToggleSection = useCallback(
+    (key: string, currentlyCollapsed: boolean) => {
+      // Collapsing while scrolled inside the section would leave the viewport
+      // on whatever content slides up into it — snap back to the section's
+      // header instead, so repeated collapses don't strand the user mid-list.
+      if (!currentlyCollapsed) {
+        const first = firstVisibleKeyRef.current;
+        if (first === `h-${key}` || first?.startsWith(`r-${key}-`)) {
+          pendingScrollKeyRef.current = key;
+        }
+      }
+      onToggleSection(key);
+    },
+    [onToggleSection],
+  );
 
   // Discrete pinch-to-zoom: each gesture changes column count by at most one
   // step. Tracks whether the current gesture has already triggered a change
@@ -189,9 +199,27 @@ function PhotoGrid({
   );
 
   const rows = useMemo(
-    () => buildRows(photos, sortBy, columnCount, collapsed),
-    [photos, sortBy, columnCount, collapsed],
+    () => buildRows(photos, sortBy, columnCount, collapsedSections),
+    [photos, sortBy, columnCount, collapsedSections],
   );
+
+  // After a collapse rebuilds the rows, land the viewport on the collapsed
+  // section's header (queued by handleToggleSection above).
+  useEffect(() => {
+    const key = pendingScrollKeyRef.current;
+    if (!key) return;
+    pendingScrollKeyRef.current = null;
+    const index = rows.findIndex(
+      (r) => r.type === 'header' && r.sectionKey === key,
+    );
+    if (index >= 0) {
+      listRef.current?.scrollToIndex({
+        index,
+        animated: false,
+        viewPosition: 0,
+      });
+    }
+  }, [rows]);
 
   const stickyIndices = useMemo(
     () =>
@@ -207,7 +235,7 @@ function PhotoGrid({
       if (item.type === 'header') {
         return (
           <Pressable
-            onPress={() => toggleCollapsed(item.sectionKey)}
+            onPress={() => handleToggleSection(item.sectionKey, item.collapsed)}
             accessibilityRole="button"
             accessibilityLabel={`${
               item.collapsed ? 'Expand' : 'Collapse'
@@ -255,7 +283,7 @@ function PhotoGrid({
         </View>
       );
     },
-    [cellSize, onPhotoPress, palette, theme.hairline, toggleCollapsed],
+    [cellSize, onPhotoPress, palette, theme.hairline, handleToggleSection],
   );
 
   const keyExtractor = useCallback((r: Row) => r.key, []);
@@ -267,6 +295,8 @@ function PhotoGrid({
       renderItem={renderItem}
       keyExtractor={keyExtractor}
       stickyHeaderIndices={stickyIndices}
+      onViewableItemsChanged={handleViewableItemsChanged}
+      viewabilityConfig={viewabilityConfig}
       onEndReached={hasMore ? onLoadMore : undefined}
       onEndReachedThreshold={8}
       initialNumToRender={columnCount * 20}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2,6 +2,7 @@ export type {
   ApiPhoto as Photo,
   PhotoFilters,
   PhotosResponse,
+  SectionsResponse,
   StatsFilters,
   StatsResponse,
 } from 'shared/types';

--- a/frontend/src/utils/groupPhotos.ts
+++ b/frontend/src/utils/groupPhotos.ts
@@ -6,7 +6,7 @@ export interface PhotoSection {
   photos: Photo[];
 }
 
-function getGroupKey(photo: Photo, sortBy: string): string {
+export function getGroupKey(photo: Photo, sortBy: string): string {
   switch (sortBy) {
     case 'iso':
       return photo.iso != null ? String(photo.iso) : '__unknown__';
@@ -48,6 +48,15 @@ function getGroupLabel(key: string, sortBy: string): string {
     default:
       return key;
   }
+}
+
+/**
+ * Convert a raw group key from /photos/sections into the same string form
+ * getGroupKey produces, so server section metadata and client-side grouping
+ * agree (both sides ultimately stringify the same JSON values).
+ */
+export function normalizeSectionKey(raw: string | number | null): string {
+  return raw === null ? '__unknown__' : String(raw);
 }
 
 /** Group a flat photo array into sections based on the current sort field. */

--- a/shared/src/schemas.ts
+++ b/shared/src/schemas.ts
@@ -3,6 +3,10 @@ import { z } from 'zod';
 export const photoFiltersSchema = z.object({
   page: z.coerce.number().int().positive().default(1),
   limit: z.coerce.number().int().positive().max(100).default(20),
+  // Absolute row offset into the sorted result set; overrides page when set.
+  // Lets the client skip past collapsed sections instead of paging through
+  // them (offsets come from /photos/sections).
+  offset: z.coerce.number().int().min(0).optional(),
   search: z.string().default(''),
   contentSearch: z.string().default(''),
   camera: z.string().default(''),
@@ -24,7 +28,15 @@ export const photoFiltersSchema = z.object({
   people: z.string().default(''),
   dogs: z.string().default(''),
   sortBy: z
-    .enum(['dateCaptured', 'filename', 'rating', 'createdAt'])
+    .enum([
+      'dateCaptured',
+      'filename',
+      'rating',
+      'createdAt',
+      'iso',
+      'aperture',
+      'camera',
+    ])
     .default('dateCaptured'),
   sortOrder: z.enum(['asc', 'desc']).default('desc'),
 });

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -27,6 +27,18 @@ export interface PhotosResponse {
   pagination: Pagination;
 }
 
+// One group in the current sort order, as returned by /photos/sections.
+// `key` is the raw group value (month string, ISO number, camera name, …);
+// null when the sort column is null for that group.
+export interface PhotoSectionMeta {
+  key: string | number | null;
+  count: number;
+}
+
+export interface SectionsResponse {
+  sections: PhotoSectionMeta[];
+}
+
 export interface PhotoFilters {
   search?: string;
   contentSearch?: string;


### PR DESCRIPTION
## Summary

Collapsing a section previously only hid photos already loaded — infinite scroll still paged through every photo in collapsed sections before reaching the next open one. Now the grid skips them entirely.

- New `/photos/sections` endpoint returns the section outline (group keys + counts) for the current filters/sort; the client uses cumulative counts as row offsets to jump past collapsed sections
- `/photos` accepts an absolute `offset` param (overrides `page`) to support those jumps; re-expanding a skipped section backfills its gap immediately
- Collapsing a section while scrolled inside it snaps the viewport back to its header
- Added ISO, aperture, and camera as sort options (with matching section grouping); filename sort is now case-insensitive so A/B/C sections stay contiguous
- Version bump to 1.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)