### PR TITLE
Fix web app crash on load: ExpoMediaLibraryNext not found

### DIFF
--- a/frontend/src/lib/download.ts
+++ b/frontend/src/lib/download.ts
@@ -1,10 +1,12 @@
 import { File, Paths } from 'expo-file-system';
 import * as MediaLibrary from 'expo-media-library';
 import * as Sharing from 'expo-sharing';
-import { Platform } from 'react-native';
 
 import { imageUrl } from './api';
 import type { Photo } from './types';
+
+// Native implementation — web builds resolve download.web.ts instead, because
+// expo-media-library has no web support and throws at import time there.
 
 /** `originalPath` is a bare filename, but guard against stray path segments. */
 function fileNameFor(photo: Photo): string {
@@ -22,11 +24,7 @@ async function shareFallback(uri: string): Promise<void> {
 /**
  * Save the full-resolution original.
  *
- * Web: fetched as a blob rather than pointed at with a plain `<a download>`,
- * because in local dev the backend is a different origin — browsers ignore the
- * download attribute cross-origin and navigate to the image instead.
- *
- * Native: `/images` sits behind the session cookie, which iOS's shared cookie
+ * `/images` sits behind the session cookie, which iOS's shared cookie
  * storage attaches to the download for us. The file lands in the cache
  * directory (system-reclaimable) and is then added to the photo library.
  *
@@ -38,21 +36,6 @@ async function shareFallback(uri: string): Promise<void> {
 export async function downloadPhoto(photo: Photo): Promise<void> {
   const url = imageUrl(photo.originalPath);
   const name = fileNameFor(photo);
-
-  if (Platform.OS === 'web') {
-    const res = await fetch(url, { credentials: 'include' });
-    if (!res.ok) throw new Error(`Download failed (${res.status})`);
-    const blob = await res.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = objectUrl;
-    link.download = name;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    URL.revokeObjectURL(objectUrl);
-    return;
-  }
 
   const file = await File.downloadFileAsync(url, new File(Paths.cache, name), {
     idempotent: true,

--- a/frontend/src/lib/download.web.ts
+++ b/frontend/src/lib/download.web.ts
@@ -1,0 +1,34 @@
+import { imageUrl } from './api';
+import type { Photo } from './types';
+
+/** `originalPath` is a bare filename, but guard against stray path segments. */
+function fileNameFor(photo: Photo): string {
+  const base = photo.originalPath.split('/').pop();
+  return base && base.length > 0 ? base : `photo-${photo.id}.jpg`;
+}
+
+/**
+ * Save the full-resolution original.
+ *
+ * Fetched as a blob rather than pointed at with a plain `<a download>`,
+ * because in local dev the backend is a different origin — browsers ignore the
+ * download attribute cross-origin and navigate to the image instead.
+ *
+ * This web variant exists so the web bundle never imports expo-media-library:
+ * that package has no web support in SDK 56 and throws "Cannot find native
+ * module 'ExpoMediaLibraryNext'" at import time, crashing the app on load.
+ */
+export async function downloadPhoto(photo: Photo): Promise<void> {
+  const url = imageUrl(photo.originalPath);
+  const res = await fetch(url, { credentials: 'include' });
+  if (!res.ok) throw new Error(`Download failed (${res.status})`);
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = objectUrl;
+  link.download = fileNameFor(photo);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
       }
     },
     "frontend": {
-      "version": "1.4.0",
+      "version": "1.6.0",
       "hasInstallScript": true,
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",


### PR DESCRIPTION
## Summary

The deployed web app crashed on load with `Cannot find native module 'ExpoMediaLibraryNext'`. The photo-download module statically imported `expo-media-library`, which has no web support in SDK 56 and throws the moment it's imported — even though the web code path never uses it.

- Split `downloadPhoto` into platform variants: `download.web.ts` (blob fetch + anchor download) and a native-only `download.ts` (photo library + share-sheet fallback, behavior unchanged)
- Metro resolves the right file per platform, so the web bundle no longer contains the native import — verified with a fresh web export

🤖 Generated with [Claude Code](https://claude.com/claude-code)