### PR TITLE
Deploy with saved settings, add Deploy settings menu

### DIFF
--- a/cli/src/App.tsx
+++ b/cli/src/App.tsx
@@ -16,7 +16,8 @@ import {
   SUPPORTED_IMAGE_FORMATS,
 } from './configFiles.js';
 import { ConfigStep } from './ConfigStep.js';
-import { DeployStep } from './DeployStep.js';
+import { DeployParamsEditor, DeployStep } from './DeployStep.js';
+import { DEPLOY_PARAMS } from './deployParams.js';
 import { LabelStep } from './LabelStep.js';
 import { loadPrefs, savePrefs } from './prefs.js';
 import { PullStep } from './PullStep.js';
@@ -53,6 +54,7 @@ type Screen =
   | 'done'
   | 'serve'
   | 'deployRun'
+  | 'deploySettings'
   | 'pull'
   | 'config'
   | 'firstRun';
@@ -444,6 +446,15 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
               { label: 'Serve on this computer', value: 'serve' },
               { label: 'Publish photos to your site', value: 'publish' },
               { label: 'Update the app on your site', value: 'app' },
+              // Only automated targets have params to edit.
+              ...(DEPLOY_PARAMS[REMOTE_TARGET]
+                ? [
+                    {
+                      label: 'Deploy settings (server address, key…)',
+                      value: 'deploySettings',
+                    },
+                  ]
+                : []),
               { label: '← Back', value: 'back' },
             ]}
             onSelect={(item) => {
@@ -451,6 +462,8 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
                 setDeployTarget('localhost');
                 savePrefs({ importDir, deployTarget: 'localhost' });
                 setScreen('serve');
+              } else if (item.value === 'deploySettings') {
+                setScreen('deploySettings');
               } else if (item.value === 'publish' || item.value === 'app') {
                 setDeployTarget(REMOTE_TARGET);
                 savePrefs({ importDir, deployTarget: REMOTE_TARGET });
@@ -591,6 +604,14 @@ export function App({ forceSetup = false }: { forceSetup?: boolean }) {
           target={deployTarget}
           action={deployAction}
           onDone={() => exit()}
+          onBack={() => setScreen('deploy')}
+        />
+      )}
+
+      {screen === 'deploySettings' && (
+        <DeployParamsEditor
+          target={REMOTE_TARGET}
+          onDone={() => setScreen('deploy')}
           onBack={() => setScreen('deploy')}
         />
       )}

--- a/cli/src/DeployStep.tsx
+++ b/cli/src/DeployStep.tsx
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import SelectInput from 'ink-select-input';
 import { useEscapeBack } from './useEscapeBack.js';
@@ -10,6 +10,7 @@ import { DEPLOY_TARGETS, deployGuidePath } from './configFiles.js';
 import {
   DEPLOY_PARAMS,
   deployScriptPath,
+  hasSavedDeployParams,
   loadDeployParams,
   pushScriptPath,
   saveDeployParams,
@@ -95,6 +96,36 @@ function openPath(p: string): void {
   }
 }
 
+/** Edit and save a target's deploy params without running anything — the
+ * "Deploy settings" entry in the Serve/deploy menu. Values persist
+ * field-by-field, exactly like the pre-deploy form. */
+export function DeployParamsEditor({
+  target,
+  onDone,
+  onBack,
+}: {
+  target: string;
+  onDone: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <Box flexDirection="column">
+      <Text bold>Deploy settings — {label(target)}</Text>
+      <Text dimColor>Enter keeps each saved value.</Text>
+      <ParamForm
+        fields={DEPLOY_PARAMS[target] ?? []}
+        initial={loadDeployParams(target)}
+        onPersist={(v) => saveDeployParams(target, v)}
+        onSubmit={(v) => {
+          saveDeployParams(target, v);
+          onDone();
+        }}
+        onCancel={onBack}
+      />
+    </Box>
+  );
+}
+
 /** Push to a remote target — either the app code (`action: 'app'`, deploy.sh) or
  * the photos + DB (`action: 'data'`, push.sh). Supported targets (have
  * DEPLOY_PARAMS) prompt for their env params — pre-filled, editable — then run
@@ -114,7 +145,12 @@ export function DeployStep({
   onBack: () => void;
 }) {
   const fields = DEPLOY_PARAMS[target];
-  const [stage, setStage] = useState<Stage>(fields ? 'params' : 'manual');
+  // Saved params from a completed earlier form → skip straight to the deploy
+  // (edit them via the deploy menu's Settings entry, or from a failure screen).
+  const skipForm = Boolean(fields) && hasSavedDeployParams(target);
+  const [stage, setStage] = useState<Stage>(
+    !fields ? 'manual' : skipForm ? 'checking' : 'params',
+  );
   const [detail, setDetail] = useState('');
   const tail = useRef<string[]>([]);
   const pendingVals = useRef<Record<string, string>>({});
@@ -200,17 +236,30 @@ export function DeployStep({
     });
   };
 
+  // Auto-start when the form is being skipped (mount only — run() is stable
+  // for the component's lifetime in all the ways that matter here).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire once on mount
+  useEffect(() => {
+    if (skipForm) run(loadDeployParams(target));
+  }, []);
+
   // Shared end-screen actions: open the live site, the full log, or finish.
+  // A failure also offers the (normally skipped) form — the saved server
+  // address or key being wrong is the usual cause.
   const endActions = (
     <SelectInput
       items={[
         ...(siteUrl ? [{ label: 'Open the site', value: 'site' }] : []),
         { label: 'Open the full log', value: 'log' },
+        ...(stage === 'failed' && fields
+          ? [{ label: 'Edit deploy settings & retry', value: 'edit' }]
+          : []),
         { label: 'Finish', value: 'finish' },
       ]}
       onSelect={(item) => {
         if (item.value === 'site') openPath(siteUrl);
         else if (item.value === 'log') openPath(logPath);
+        else if (item.value === 'edit') setStage('params');
         else onDone();
       }}
     />

--- a/cli/src/deployParams.ts
+++ b/cli/src/deployParams.ts
@@ -190,6 +190,15 @@ function readStore(): Store {
   }
 }
 
+/** True once the form has been completed for a target: every param key is
+ * present in the saved store (empty string is a real answer — e.g. the default
+ * SSH key). Lets re-deploys skip the form entirely. */
+export function hasSavedDeployParams(target: string): boolean {
+  const saved = readStore()[target];
+  if (!saved) return false;
+  return (DEPLOY_PARAMS[target] ?? []).every((p) => p.key in saved);
+}
+
 /** Saved params for a target, back-filled with each param's default. */
 export function loadDeployParams(target: string): Record<string, string> {
   const saved = readStore()[target] ?? {};


### PR DESCRIPTION
## Summary

Re-deploying meant stepping through the same param form (host, key, dir, URL) every time, even though the answers were already saved.

- Once the form has been completed for a target, "Publish photos" and "Update the app" skip it and start immediately with the saved values; first-time runs still get the form
- New "Deploy settings" entry in the Serve / deploy menu edits the saved values (same form, including the live SSH connection test) without running a deploy
- A failed deploy's end screen now offers "Edit deploy settings & retry", since a wrong saved host/key is the usual cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)